### PR TITLE
Include instructions for installing via script tag

### DIFF
--- a/docs/feature-flagging/randomization-sdk/client-sdks/javascript.md
+++ b/docs/feature-flagging/randomization-sdk/client-sdks/javascript.md
@@ -32,7 +32,20 @@ npm install @eppo/js-client-sdk
 ```
 
 </TabItem>
+
+<TabItem value="script" label="Script">
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@eppo/js-client-sdk@latest/dist/eppo-sdk.min.js"></script>
+```
+</TabItem>
 </Tabs>
+
+If you install via a `<script>` tag, include a version in the URL to install a specific version of the SDK (or use `latest` as the version to install the latest SDK version):
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@eppo/js-client-sdk@{version}/dist/eppo-sdk.min.js"></script>
+```
 
 ### 2. Define an Assignment Logger
 


### PR DESCRIPTION
Some consumers might want to install the frontend SDK via a `<script>` tag. This is possible by loading the SDK from JSDelivr - an open source CDN that distributes the minified SDK source. I added documentation for how to install it.

Related PR for setting up webpack and JSDelivr: https://github.com/Eppo-exp/js-client-sdk/pull/5