### PR TITLE
Added more details to BQ configuration

### DIFF
--- a/docs/connecting-your-data/data-warehouses/connecting-to-bigquery.md
+++ b/docs/connecting-your-data/data-warehouses/connecting-to-bigquery.md
@@ -44,7 +44,7 @@ If you would like to provide more granular access, you can provide us with read-
 ## Enter credentials into Eppo
 
 1. Open the JSON file created in Step 10 under _Create a Service Account_
-2. Log in to your Eppo account at [eppo.cloud](eppo.cloud), enter the values into the form fill as shown below, and click **Test and Save Connection**
+2. Log in to your Eppo account at [eppo.cloud](https://eppo.cloud/), enter the values into the form fill as shown below, and click **Test and Save Connection**
  - **Connection type** - BigQuery
  - **Service Account JSON** - From step 10 above
  - **BigQuery Dataset** - `eppo_output`

--- a/docs/connecting-your-data/data-warehouses/connecting-to-bigquery.md
+++ b/docs/connecting-your-data/data-warehouses/connecting-to-bigquery.md
@@ -44,6 +44,11 @@ If you would like to provide more granular access, you can provide us with read-
 ## Enter credentials into Eppo
 
 1. Open the JSON file created in Step 10 under _Create a Service Account_
-2. Enter the values into the form fill as shown below, then click **Test and Save Connection**
+2. Log in to your Eppo account at [eppo.cloud](eppo.cloud), enter the values into the form fill as shown below, and click **Test and Save Connection**
+ - **Connection type** - BigQuery
+ - **Service Account JSON** - From step 10 above
+ - **BigQuery Dataset** - `eppo_output`
+ - **BigQuery Project** - Name of the BQ project to which `eppo_output` belongs
+ - **BigQuery Region** - The region in which you created the `eppo_output` dataset
    ![Bigquery warehouse connection](../../../static/img/connecting-data/BigQuery-Connection-UI_V2.png)
 3. Eppo uses [Google Secret Manager](https://cloud.google.com/secret-manager) to store and manage your credentials. Credentials are never stored in plaintext, and Secret Manager can only be accessed via authorized roles in GCP, where all usage is monitored and logged.


### PR DESCRIPTION
The doc for configuring BQ doesn't have the same description of what to use for each field that we have for SF and Redshift. This just adds a short description of what to use for each field.

Motivated by some friction that Origin had setting up their connection