### PR TITLE
Disable dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,6 +108,11 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      colorMode: {
+        defaultMode: 'light',
+        disableSwitch: true,
+        respectPrefersColorScheme: false,
+      },
     }),
 };
 


### PR DESCRIPTION
Dark mode currently doesn't look good; especially with the purple links that become illegible. Turn off until we can find a theme that works.