### PR TITLE
Fix broken links

### DIFF
--- a/docs/prerequisites/feature-flagging/index.md
+++ b/docs/prerequisites/feature-flagging/index.md
@@ -4,7 +4,7 @@
 
 The first step to running experiments is setting up randomization. Randomization refers to a function in your code that can assign subjects (e.g users) to variants (e.g `control`, `treatment`) given an experiment configuration. If you don't already have a way to randomize users in your app, you'll need to setup one of the following options:
 
-- [Eppo's Randomization SDKs](./randomization-sdk)
+- [Eppo's Randomization SDKs](./randomization-sdk/)
 - A third party tool such as [Launch Darkly](./launch-darkly) or [Optimizely](./optimizely)
 - An internal tool that you build yourself
 

--- a/docs/prerequisites/index.md
+++ b/docs/prerequisites/index.md
@@ -9,5 +9,5 @@ To analyze experiments on Eppo you must first:
 
 ![Data inputs](../../static/img/feature-flagging/data-inputs.png)
 
-If your infastructure lines up with this diagram, you're ready to go! If you are new to experimentation or need help understanding best practices, read further into our guides on [feature flagging](./feature-flagging) and [event logging](./event-logging).
+If your infastructure lines up with this diagram, you're ready to go! If you are new to experimentation or need help understanding best practices, read further into our guides on [feature flagging](./feature-flagging/) and [event logging](./event-logging/).
 


### PR DESCRIPTION
The links on the prerequisites page were broken - should end with a slash '/' when it links to a directory