### PR TITLE
fixed missing schema name typo

### DIFF
--- a/docs/connecting-your-data/data-warehouses/connecting-to-redshift.md
+++ b/docs/connecting-your-data/data-warehouses/connecting-to-redshift.md
@@ -51,7 +51,7 @@ _**NOTE**: The AWS Redshift query editor will not run multi-statement queries; i
 4. Create a schema for Eppo to write intermediate results and temporary tables.
 ```sql
 CREATE SCHEMA IF NOT EXISTS eppo_output;
-GRANT ALL ON SCHEMA TO eppo_user;
+GRANT ALL ON SCHEMA eppo_output TO eppo_user;
 ```
 
 ## Gather Redshift connection details


### PR DESCRIPTION
Instawork noticed that we are missing the schema name in part of our connecting redshift docs