### PR TITLE
[logo] update eppo relationship map with new logo on experiment quickstart

### DIFF
--- a/docs/feature-flags/sdks/server-sdks/python.md
+++ b/docs/feature-flags/sdks/server-sdks/python.md
@@ -58,7 +58,7 @@ The SDK will invoke the `log_assignment` function with an `assignment` object th
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
 
-## 3. Assign Experiment Variations
+## 3. Assign variations
 Assigning users to flags or experiments with a single `get_assignment` function:
 
 ```python

--- a/docs/quick-starts/your-first-experiment-analysis.md
+++ b/docs/quick-starts/your-first-experiment-analysis.md
@@ -8,7 +8,7 @@ Follow this quickstart to get your first experiment set up on Eppo.
 
 ## Overview
 
-<img src="https://user-images.githubusercontent.com/111296875/186039257-d2d9f8db-e42a-45e7-af5f-19c899d54339.jpg" width="650" height="780" />
+<img src="https://user-images.githubusercontent.com/1095808/202587691-167d7c80-1f3c-4436-a963-c43790e95ac3.jpg" width="650" height="780" />
 
 1. [Prep your data warehouse and set up experiment assignment](#1-prep-your-data-warehouse-and-set-up-experiment-assignment)
 2. [Create an Eppo account](#2-create-eppo-account)


### PR DESCRIPTION
New diagram contains our updated logo:

<img width="1552" alt="Screen Shot 2022-11-17 at 4 22 03 PM" src="https://user-images.githubusercontent.com/1095808/202588143-ce3d936c-bc88-48b1-867b-55fcadeef459.png">