### PR TITLE
Fix Ruby syntax highlighting

### DIFF
--- a/docs/feature-flags/sdks/server-sdks/index.md
+++ b/docs/feature-flags/sdks/server-sdks/index.md
@@ -16,3 +16,4 @@ Eppo's server-side SDKs may be used to implement flags and run experiments in yo
 - [Python](./python.md)
 - [Java](./java.md)
 - [Go](./go.md)
+- [Ruby](./ruby.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,7 @@ const config = {
         copyright: `Copyright © ${new Date().getFullYear()} Eppo, Inc.`,
       },
       prism: {
-        additionalLanguages: ['java', 'groovy'],
+        additionalLanguages: ['java', 'groovy', 'ruby'],
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },


### PR DESCRIPTION
I just realized that the syntax highlighting was broken, but it looks like an easy fix. I tested this out locally and confirmed that it works

Before

![Screen Shot 2023-01-12 at 12 23 51 PM](https://user-images.githubusercontent.com/2822951/212173507-e397a118-512e-4689-9eb4-f322fc73c74c.png)

After

![Screen Shot 2023-01-12 at 12 24 00 PM](https://user-images.githubusercontent.com/2822951/212173470-53643e21-0771-4fb3-98f5-da98d6a8111a.png)