### PR TITLE
EPD-946 [Docs] More event logging configuration examples

### DIFF
--- a/docs/experiments/prerequisites/event-logging/index.md
+++ b/docs/experiments/prerequisites/event-logging/index.md
@@ -95,8 +95,8 @@ const variation = eppoClient.getAssignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT
 import { IAssignmentLogger, init } from '@eppo/node-server-sdk';
 
 // Initialize mParticle
-var mParticle = require('mparticle');
-var api = new mParticle.EventsApi(new mParticle.Configuration(
+const mParticle = require('mparticle');
+const api = new mParticle.EventsApi(new mParticle.Configuration(
     '<MPARTICLE_API_KEY>', 
     '<MPARTICLE_API_SECRET>'
 ));
@@ -104,10 +104,10 @@ var api = new mParticle.EventsApi(new mParticle.Configuration(
 // Define logAssignment so that it logs events to mParticle
 const assignmentLogger: IAssignmentLogger = {
   logAssignment(assignment) {
-    var batch = new mParticle.Batch(mParticle.Batch.Environment.development);
+    const batch = new mParticle.Batch(mParticle.Batch.Environment.development);
     batch.user_identities = new mParticle.UserIdentities();
     batch.user_identities.customerid = assignment.subject
-    var event = new mParticle.AppEvent(
+    const event = new mParticle.AppEvent(
       mParticle.AppEvent.CustomEventType.navigation, 
       'Eppo Randomization Event'
     );

--- a/docs/experiments/prerequisites/event-logging/index.md
+++ b/docs/experiments/prerequisites/event-logging/index.md
@@ -9,8 +9,6 @@ Eppo's SDKs include either an assignment logger base class or an interface, in w
 * [mParticle](#mparticle)
 * [Snowplow](#snowplow)
 
-Similar patterns can be adopted for Eppo's SDKs in other languages, e.g. Java, Python, and etc.
-
 The object passed into the assignment logger function contains the following fields:
 
 | Field | Description | Example |
@@ -21,6 +19,7 @@ The object passed into the assignment logger function contains the following fie
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+The examples below are written in JavaScript, but similar patterns can be adapted for all of Eppo's SDKs including Java, Python, and etc.
 
 ## Segment
 

--- a/docs/experiments/prerequisites/event-logging/index.md
+++ b/docs/experiments/prerequisites/event-logging/index.md
@@ -1,24 +1,169 @@
 # Event logging
 
-The second prerequisite to running experiments on Eppo is logging application events to your warehouse.
+The second prerequisite to running experiments on Eppo is logging application events to your warehouse. It is best practice to centralize application logging as much as possible, and Eppo's SDKs work seamlessly with most logging tools, meaning you can keep using your favorite logger. The last step would be configuring your logging tool, e.g. Segment, to push your data into your data warehouse.
 
-It's best practice to centralize application logging as much as possible. For illustration using a basic web app and Segment as an event logger, you might define the following logging functions on the your client (e.g a single page app):
+Eppo's SDKs include either an assignment logger base class or an interface, in which you can define a method according to your logging requirements. Examples are shown below in Eppo's Node SDK for logging with some common event loggers: 
 
-```js
-// logging.js
+* [Segment](#segment)
+* [Rudderstack](#rudderstack)
+* [mParticle](#mparticle)
+* [Snowplow](#snowplow)
 
-function logEvent(eventData) {
-  segment.track(eventData)
-}
+Similar patterns can be adopted for Eppo's SDKs in other languages, e.g. Java, Python, and etc.
+
+
+## Segment
+
+```javascript
+// Import Eppo's assignment logger interface and client initializer
+import { IAssignmentLogger, init } from '@eppo/node-server-sdk';
+
+// Connect to Segment
+const Analytics = require('analytics-node');
+const analytics = new Analytics('<SEGMENT_WRITE_KEY>');
+
+// Define logAssignment so that it logs events to Segment
+const assignmentLogger: IAssignmentLogger = {
+  logAssignment(assignment) {
+    analytics.track({
+      userId: assignment.subject,
+      event: 'Eppo Randomization Event',
+      properties: assignment,
+    });
+  },
+};
+
+// Initialize the client
+await init({
+  apiKey: '<API_KEY>',
+  assignmentLogger,
+});
+
+// Then every call to getAssignment will also log the event to Segment
+const eppoClient = EppoSdk.getInstance();
+const variation = eppoClient.getAssignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>", {});
 ```
 
-and the same function on your server (this example assumes a Python backend):
+## Rudderstack
 
-```python
-# logging.py
+```javascript
+// Import Eppo's assignment logger interface and client initializer
+import { IAssignmentLogger, init } from '@eppo/node-server-sdk';
 
-def log_event(event_data):
-    segment.track(event_data)
+// Connect to Rudderstack
+const Analytics = require('@rudderstack/rudder-sdk-node');
+const analytics = new Analytics('<RUDDERSTACK_WRITE_KEY>', {
+  dataPlaneUrl: DATA_PLANE_URL,
+});
+
+// Define logAssignment so that it logs events to Rudderstack
+const assignmentLogger: IAssignmentLogger = {
+  logAssignment(assignment) {
+    analytics.track({
+      userId: assignment.subject,
+      event: 'Eppo Randomization Event',
+      properties: assignment,
+    });
+  },
+};
+
+// Initialize the client
+await init({
+  apiKey: '<API_KEY>',
+  assignmentLogger,
+});
+
+// Then every call to getAssignment will also log the event to Rudderstack
+const eppoClient = EppoSdk.getInstance();
+const variation = eppoClient.getAssignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>", {});
 ```
 
-All client logging would use the JS function and all backend would use the Python function. The last piece would be configuring Segment to route your data into your data warehouse.
+## mParticle
+
+```javascript
+// Import Eppo's assignment logger interface and client initializer
+import { IAssignmentLogger, init } from '@eppo/node-server-sdk';
+
+// Initialize mParticle
+var mParticle = require('mparticle');
+var api = new mParticle.EventsApi(new mParticle.Configuration(
+    '<MPARTICLE_API_KEY>', 
+    '<MPARTICLE_API_SECRET>'
+));
+
+// Define logAssignment so that it logs events to mParticle
+const assignmentLogger: IAssignmentLogger = {
+  logAssignment(assignment) {
+    var batch = new mParticle.Batch(mParticle.Batch.Environment.development);
+    batch.user_identities = new mParticle.UserIdentities();
+    batch.user_identities.customerid = assignment.subject
+    var event = new mParticle.AppEvent(
+      mParticle.AppEvent.CustomEventType.navigation, 
+      'Eppo Randomization Event'
+    );
+    event.custom_attributes = assignment;
+    batch.addEvent(event);
+    api.uploadEvents([batch]);
+  },
+};
+
+// Initialize the client
+await init({
+  apiKey: '<API_KEY>',
+  assignmentLogger,
+});
+
+// Then every call to getAssignment will also log the event to mParticle
+const eppoClient = EppoSdk.getInstance();
+const variation = eppoClient.getAssignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>", {});
+```
+
+## Snowplow
+
+This examples shows the setup for Snowplow's Node.js Tracker v3 SDK.
+
+```javascript
+// Import Eppo's assignment logger interface and client initializer
+import { IAssignmentLogger, init } from '@eppo/node-server-sdk';
+
+// Initialize Snowplow
+import { tracker, gotEmitter, buildSelfDescribingEvent } from '@snowplow/node-tracker';
+const emit = gotEmitter(
+  'collector.mydomain.net', // Collector endpoint
+  snowplow.HttpProtocol.HTTPS,
+  8080,
+  snowplow.HttpMethod.POST,
+  1
+);
+const track = tracker(
+  [emit], 
+  'Eppo Randomization Events', 
+  '<SNOWPLOW_APP_ID>', 
+  false
+);
+
+// Define logAssignment so that it logs events to Snowplow
+const assignmentLogger: IAssignmentLogger = {
+  logAssignment(assignment) {
+    track.track(buildSelfDescribingEvent({
+      event: {
+        schema: "iglu:com.example_company/eppo-event/jsonschema/1-0-2",
+        data: {
+          userId: assignment.subject,
+          properties: assignment,
+        }
+      }
+    }));
+  },
+};
+
+// Initialize the client
+await init({
+  apiKey: '<API_KEY>',
+  assignmentLogger,
+});
+
+// Then every call to getAssignment will also log the event to Snowplow
+const eppoClient = EppoSdk.getInstance();
+const variation = eppoClient.getAssignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>", {});
+```

--- a/docs/experiments/prerequisites/event-logging/index.md
+++ b/docs/experiments/prerequisites/event-logging/index.md
@@ -11,7 +11,7 @@ Eppo's SDKs include either an assignment logger base class or an interface, in w
 
 Similar patterns can be adopted for Eppo's SDKs in other languages, e.g. Java, Python, and etc.
 
-The object passed into the assignment logger function contrains the following fields:
+The object passed into the assignment logger function contains the following fields:
 
 | Field | Description | Example |
 | --------- | ------- | ---------- |

--- a/docs/experiments/prerequisites/event-logging/index.md
+++ b/docs/experiments/prerequisites/event-logging/index.md
@@ -11,6 +11,16 @@ Eppo's SDKs include either an assignment logger base class or an interface, in w
 
 Similar patterns can be adopted for Eppo's SDKs in other languages, e.g. Java, Python, and etc.
 
+The object passed into the assignment logger function contrains the following fields:
+
+| Field | Description | Example |
+| --------- | ------- | ---------- |
+| `experiment` (string) | An Eppo experiment key | "recommendation_algo" |
+| `subject` (string) | An identifier of the subject or user assigned to the experiment variation | UUID |
+| `variation` (string) | The experiment variation the subject was assigned to | "control" |
+| `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
+| `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
+
 
 ## Segment
 

--- a/docs/feature-flags/sdks/client-sdks/android.md
+++ b/docs/feature-flags/sdks/client-sdks/android.md
@@ -74,6 +74,9 @@ The SDK will invoke the `logAssignment` function with an `Assignment` object tha
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 

--- a/docs/feature-flags/sdks/client-sdks/javascript.md
+++ b/docs/feature-flags/sdks/client-sdks/javascript.md
@@ -107,6 +107,9 @@ The SDK will invoke the `logAssignment` function with an `assignment` object tha
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 

--- a/docs/feature-flags/sdks/server-sdks/go.md
+++ b/docs/feature-flags/sdks/server-sdks/go.md
@@ -90,6 +90,9 @@ The SDK will invoke the `LogAssignment` function with an `event` object that con
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 

--- a/docs/feature-flags/sdks/server-sdks/java.md
+++ b/docs/feature-flags/sdks/server-sdks/java.md
@@ -60,6 +60,9 @@ The SDK will invoke the `logAssignment` function with an `event` object that con
 | `timestamp` (Date) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (Map<String, EppoValue>) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `Map.of("device", EppoValue.valueOf("iOS")` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 Assigning users to flags or experiments with a single `getAssignment` function:

--- a/docs/feature-flags/sdks/server-sdks/node.md
+++ b/docs/feature-flags/sdks/server-sdks/node.md
@@ -79,6 +79,9 @@ The SDK will invoke the `logAssignment` function with an `assignment` object tha
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 

--- a/docs/feature-flags/sdks/server-sdks/python.md
+++ b/docs/feature-flags/sdks/server-sdks/python.md
@@ -57,6 +57,9 @@ The SDK will invoke the `log_assignment` function with an `assignment` object th
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 Assigning users to flags or experiments with a single `get_assignment` function:

--- a/docs/feature-flags/sdks/server-sdks/ruby.md
+++ b/docs/feature-flags/sdks/server-sdks/ruby.md
@@ -64,6 +64,9 @@ The SDK will invoke the `log_assignment` function with an `assignment` object th
 | `timestamp` (string) | The time when the subject was assigned to the variation | 2021-06-22T17:35:12.000Z |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }` |
 
+:::note
+More examples of logging (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/experiments/prerequisites/event-logging/) page.
+:::
 
 ## 3. Assign variations
 Assigning users to flags or experiments with a single `get_assignment` function:


### PR DESCRIPTION
[EPD-946](https://linear.app/eppo/issue/EPD-946/[docs]-more-event-logging-configuration-examples)

Added examples as captured on Linear, although I can't guarantee that all of these work exactly as advertised. mParticle and Snowplow, in particular, have more complicated SDKs and I didn't personally try them out myself.

Also, I included links to the event-logging page on each SDK page EXCEPT for iOS because I didn't see anything in the docs about assignment logging and was not sure if it was supported by the iOS SDK.