### PR TITLE
update java sdk version listed from 1.0.2 => 1.1.0

### DIFF
--- a/docs/feature-flags/sdks/server-sdks/java.md
+++ b/docs/feature-flags/sdks/server-sdks/java.md
@@ -14,7 +14,7 @@ In your pom.xml, add the SDK package as a dependency:
 <dependency>
   <groupId>cloud.eppo</groupId>
   <artifactId>eppo-server-sdk</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
this was surfaced in the Inventa POC where the used the listed (deprecated) version which called our deprecated API endpoint. updating the docs here to be current.

https://eppo-group.slack.com/archives/C04EXAWHFRA/p1675363766135449