### PR TITLE
Slack notifications: add a opening paragraph

### DIFF
--- a/docs/administration/slack-notifications.md
+++ b/docs/administration/slack-notifications.md
@@ -1,5 +1,7 @@
 # Slack notifications
 
+The Eppo App for Slack allows you to receive notifications for important updates on your experiments, such as when Eppo detect a [traffic imbalance](../experiments/interpreting-experiments/traffic) in your assignments.
+
 <img width="440" alt="data issues alert" src="https://user-images.githubusercontent.com/90637953/213244183-a3580e3b-e077-4fc5-9bbb-2dc307660ebd.png" /> &ensp;
 <img width="440" alt="status change alert" src="https://user-images.githubusercontent.com/90637953/213244188-3dbd1333-185e-4416-b925-d36bbac08223.png" /> &ensp;
 <img width="440" alt="metrics alert" src="https://user-images.githubusercontent.com/90637953/213244191-5cfcceec-5019-4d82-bd40-ead2aeacd20e.png" />
@@ -41,7 +43,7 @@ To remove the Slack channel from this metirc, click on "Configure" and turn off 
 
 ## Notification Triggers
 ### A data problem on an experiment
-* When there is a traffic imbalance detected
+* When Eppo detects a [traffic imbalance](../experiments/interpreting-experiments/traffic) in your assignments
 * When there is an error and the experiment results cannot be refreshed
 
 ### A status change on an experiment


### PR DESCRIPTION
Adding a short opening paragraph, primarily so that the Slack preview doesn't look borked