### PR TITLE
update copy in docs to reflect api permission modal

### DIFF
--- a/docs/feature-flags/sdks/client-sdks/android.md
+++ b/docs/feature-flags/sdks/client-sdks/android.md
@@ -30,7 +30,7 @@ During initialization, the SDK sends an API request to Eppo to retrieve the most
 <br />
 
 :::note
-API Keys used with Client SDKs should have only ‘Randomization READ’ permissions. 
+API Keys used with Client SDKs should have only 'Feature Flagging READ' permissions on, with all other permissions set to 'No Access'.
 :::
 
 <br />

--- a/docs/feature-flags/sdks/client-sdks/ios.md
+++ b/docs/feature-flags/sdks/client-sdks/ios.md
@@ -26,7 +26,7 @@ During initialization, the SDK sends an API request to Eppo to retrieve the most
 <br />
 
 :::note
-API Keys used with Client SDKs should have only ‘Randomization READ’ permissions.
+API Keys used with Client SDKs should have only 'Feature Flagging READ' permissions on, with all other permissions set to 'No Access'.
 :::
 
 <br />

--- a/docs/feature-flags/sdks/client-sdks/javascript.md
+++ b/docs/feature-flags/sdks/client-sdks/javascript.md
@@ -67,7 +67,7 @@ During initialization, the SDK sends an API request to Eppo to retrieve the most
 <br />
 
 :::note
-API Keys used with Client SDKs should have only ‘Randomization READ’ permissions
+API Keys used with Client SDKs should have only 'Feature Flagging READ' permissions on, with all other permissions set to 'No Access'.
 :::
 
 <br />


### PR DESCRIPTION
`Randomization` was renamed to `Feature Flagging` in the app but not here in the docs. Updating!