### PR TITLE
Fix broken Experiment Assignment links

### DIFF
--- a/docs/experiments/prerequisites/experiment-assignment/index.md
+++ b/docs/experiments/prerequisites/experiment-assignment/index.md
@@ -24,8 +24,8 @@ It's ok for this table to contain duplicate rows for the same subject, however f
 
 Refer to our tool specific guides to understand how to log assignments to your warehouse:
 
-- [Logging assignment data using Eppo's SDKs](./eppo/)
-- [Exporting assignment data from Launch Darkly](./launch-darkly)
-- [Exporting assignment data from Optimizely](./optimizely)
+- [Logging assignment data using Eppo's SDKs](experiment-assignment/eppo/)
+- [Exporting assignment data from Launch Darkly](experiment-assignment/launch-darkly)
+- [Exporting assignment data from Optimizely](experiment-assignment/optimizely)
 
 For all other systems, email us at feature-flagging@geteppo.com and we'll happily walk you through the process.

--- a/docs/experiments/prerequisites/experiment-assignment/index.md
+++ b/docs/experiments/prerequisites/experiment-assignment/index.md
@@ -24,8 +24,8 @@ It's ok for this table to contain duplicate rows for the same subject, however f
 
 Refer to our tool specific guides to understand how to log assignments to your warehouse:
 
-- [Logging assignment data using Eppo's SDKs](experiment-assignment/eppo/)
-- [Exporting assignment data from Launch Darkly](experiment-assignment/launch-darkly)
-- [Exporting assignment data from Optimizely](experiment-assignment/optimizely)
+- [Logging assignment data using Eppo's SDKs](./eppo/)
+- [Exporting assignment data from Launch Darkly](./launch-darkly)
+- [Exporting assignment data from Optimizely](./optimizely)
 
 For all other systems, email us at feature-flagging@geteppo.com and we'll happily walk you through the process.

--- a/docs/quick-starts/your-first-experiment-analysis.md
+++ b/docs/quick-starts/your-first-experiment-analysis.md
@@ -39,7 +39,7 @@ This quickstart assumes that you already have assignment logs tracked in your da
     | 2021-07-17T18:57:13.000Z	 | 49980400511307080 | Revenue | 45.5695	|
     | 2021-07-17T18:57:13.000Z	 | 2281323415877132491 | Subscription | 1 |
 
-If you do not have a experiment assignment tool integrated, please refer to the [experiment assignment](../experiments/prerequisites/experiment-assignment) section for more instructions.
+If you do not have a experiment assignment tool integrated, please refer to the [experiment assignment](../experiments/prerequisites/experiment-assignment/) section for more instructions.
 
 If you have a experiment assignment tool integrated but do not have an assignment table set up in your data warehouse, please follow the instructions [here](../experiments/connecting-your-data/assignment-tables/) to log your assignment data.
 


### PR DESCRIPTION
There were three broken links on the [Experiment assignment](http://localhost:3000/experiments/prerequisites/experiment-assignment) page (see below):
- Logging assignment data using Eppo's SDKs
- Exporting assignment data from Launch Darkly
- Exporting assignment data from Optimizely

This PR fixes them. 

You'll may continue to have trouble with your structure and deep links since you are leveraging autogeneration in your sidebar.