### PR TITLE
android: add instructions to set application(application) before buildAndInit

### DIFF
--- a/docs/feature-flags/sdks/client-sdks/android.md
+++ b/docs/feature-flags/sdks/client-sdks/android.md
@@ -60,6 +60,7 @@ AssignmentLogger logger = new AssignmentLogger() {
 EppoClient eppoClient = new EppoClient.Builder()
     .apiKey("YOUR_API_KEY")
     .assignmentLogger(assignmentLogger)
+    .application(application)
     .buildAndInit();
 ```
 


### PR DESCRIPTION
**customer feedback**

<img width="586" alt="Screenshot 2023-05-19 at 10 36 01 AM" src="https://github.com/Eppo-exp/eppo-docs/assets/57361/810e70ea-8d1a-4922-8611-6f0eaa01e1af">

**why?**

using the builder pattern, when `buildAndInit` is called it assumes that `application` is not null

<img width="803" alt="Screenshot 2023-05-19 at 10 36 29 AM" src="https://github.com/Eppo-exp/eppo-docs/assets/57361/e32eeb2c-ab5a-4d1b-838c-5e0ce29023cf">
