### PR TITLE
Update _redirects to handle all URLs from showing netlify

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,2 @@
-https://adoring-yonath-6ecb9d.netlify.app https://docs.geteppo.com 301!
-http://adoring-yonath-6ecb9d.netlify.app  http://docs.geteppo.com  301!
+https://adoring-yonath-6ecb9d.netlify.app/* https://docs.geteppo.com/:splat 301!
+http://adoring-yonath-6ecb9d.netlify.app/*  http://docs.geteppo.com/:splat  301!


### PR DESCRIPTION
**previously eppo's netlify docs page was being indexed by google**

<img width="803" alt="Screenshot 2023-05-19 at 10 45 41 AM" src="https://github.com/Eppo-exp/eppo-docs/assets/57361/ab2026c3-5679-4a42-9eaa-75b771bd4c25">

**fixed the root path**

https://eppo-group.slack.com/archives/C037Q5SPQET/p1682565684341709?thread_ts=1682565028.152469&cid=C037Q5SPQET

**problem - lukas reports thats the android sdk docs are showing up as netlify**

https://eppo-group.slack.com/archives/C02P01LSEE8/p1684517678910889

<img width="803" alt="Screenshot 2023-05-19 at 10 45 41 AM" src="https://github.com/Eppo-exp/eppo-docs/assets/57361/221d7e11-9844-4f07-9e44-fb8989e75e1a">

**changes**

The existing redirect rules only handle the top level URL.

* `https://adoring-yonath-6ecb9d.netlify.app` redirects and thus is removed from google’s index
* `https://adoring-yonath-6ecb9d.netlify.app/feature-flags/sdks/server-sdks/` (or any param/query string) does not

Expanding the redirect rules to handle all urls.

**reference**

https://docs.netlify.com/routing/redirects/redirect-options/#splats