### PR TITLE
disable algolia docsearch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,17 +65,17 @@ async function createConfig () {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
 
-      algolia: {
-        // // The application ID provided by Algolia
-        // appId: 'ECM1HGQRTR',
+      // algolia: {
+      //   // // The application ID provided by Algolia
+      //   // appId: 'ECM1HGQRTR',
 
-        // // Public API key: it is safe to commit it
-        // apiKey: 'da6798ec5b7565fc622f8614143d55b3',
+      //   // // Public API key: it is safe to commit it
+      //   // apiKey: 'da6798ec5b7565fc622f8614143d55b3',
 
-        // indexName: 'geteppo'
+      //   // indexName: 'geteppo'
 
-        // // ... other Algolia params
-      },
+      //   // // ... other Algolia params
+      // },
       navbar: {
         // title: 'Eppo',
         logo: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,17 +65,17 @@ async function createConfig () {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
 
-      algolia: {
-        // The application ID provided by Algolia
-        appId: 'KJBY2Y7V19',
+      // algolia: {
+      //   // // The application ID provided by Algolia
+      //   // appId: 'ECM1HGQRTR',
 
-        // Public API key: it is safe to commit it
-        apiKey: 'da6798ec5b7565fc622f8614143d55b3',
+      //   // // Public API key: it is safe to commit it
+      //   // apiKey: 'da6798ec5b7565fc622f8614143d55b3',
 
-        indexName: 'docs'
+      //   // indexName: 'geteppo'
 
-        // ... other Algolia params
-      },
+      //   // // ... other Algolia params
+      // },
       navbar: {
         // title: 'Eppo',
         logo: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,17 +65,17 @@ async function createConfig () {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
 
-      // algolia: {
-      //   // // The application ID provided by Algolia
-      //   // appId: 'ECM1HGQRTR',
+      algolia: {
+        // The application ID provided by Algolia
+        appId: 'KJBY2Y7V19',
 
-      //   // // Public API key: it is safe to commit it
-      //   // apiKey: 'da6798ec5b7565fc622f8614143d55b3',
+        // Public API key: it is safe to commit it
+        apiKey: 'da6798ec5b7565fc622f8614143d55b3',
 
-      //   // indexName: 'geteppo'
+        indexName: 'docs'
 
-      //   // // ... other Algolia params
-      // },
+        // ... other Algolia params
+      },
       navbar: {
         // title: 'Eppo',
         logo: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,15 +66,15 @@ async function createConfig () {
     ({
 
       algolia: {
-        // The application ID provided by Algolia
-        appId: 'XFI8PX63MB',
+        // // The application ID provided by Algolia
+        // appId: 'ECM1HGQRTR',
 
-        // Public API key: it is safe to commit it
-        apiKey: '6ac33fd9492c00c1b395088df31bb46f',
+        // // Public API key: it is safe to commit it
+        // apiKey: 'da6798ec5b7565fc622f8614143d55b3',
 
-        indexName: 'geteppo'
+        // indexName: 'geteppo'
 
-        // ... other Algolia params
+        // // ... other Algolia params
       },
       navbar: {
         // title: 'Eppo',


### PR DESCRIPTION
Chas and I are working to get access to https://docsearch.algolia.com/ but its taking a bit of time; we want to disable the algolia search for now so that customers don't see a bad state.

<img width="1440" alt="Screenshot 2023-06-26 at 10 36 10 AM" src="https://github.com/Eppo-exp/eppo-docs/assets/57361/a47f3529-830f-4cd7-b711-c87742ff0674">
