### PR TITLE
light pass on assignment SQLs doc

### DIFF
--- a/docs/data-management/definitions/assignment-sql.md
+++ b/docs/data-management/definitions/assignment-sql.md
@@ -1,8 +1,8 @@
 # Assignment SQL
 
-When you write an **Assignment SQL**, you're defining which entities will be assigned to which experiment and variation, and at what time.
+**Assignment SQLs** tell Eppo where to find a log of every time a subject (e.g., user) was enrolled into an experiment, the name of that experiment, and the variant that was assigned. Assignment SQLs can point to either logs from Eppo's SDK or from existing internal or third party randomization tools. You can also create multiple assignment sources if you use a combination of assignment methods.
 
-You can optionally include any [properties](./property-sql.md) that you want to be able to slice/dice the analysis by.
+Assignment SQLS can also include any [properties](./property-sql.md) by which you want to split results.
 
 ```sql
 SELECT
@@ -10,7 +10,8 @@ SELECT
     experiment_name,
     variant_name,
     user_id,
-    browser,
+    -- optional properties that may be later used to split results
+    browser, 
     device_type
 FROM mydb.myschema.assignments
 ```
@@ -27,19 +28,17 @@ In this example, `user_id` is assigned to `experiment_name` in the `variant_name
 
 ![Create Assignment SQL](/img/building-experiments/create-assignment-sql.png)
 
-3. Select the subject of the Assignment SQL
+3. Select the subject (randomized unit) of the Assignment SQL. To learn more about specifying multiple randomization units Eppo, see the [entities page](/data-management/entities).
 
 ![Select user as entity](/img/building-experiments/select-user-as-entity.png)
 
-Entities are the randomization units of your experiment. By default, entities in Eppo are **User**, but you can also [create your own customized entities](../entities.md) and attach Assignment SQL's to them.
-
 4. Name your Assignment SQL
 
-5. Write SQL in the SQL editor to pull assignments from data warehouse and click **Run**
+5. Write SQL in the SQL editor to pull assignments from your data warehouse and click **Run**
 
-Recall tht you should have an assignment table in your data warehouse with certain column types.
+At a minimum, this query should return a unique identifier for the subject (e.g., `user_id`), a unique identifier for the experiment, the variant the subject received, and a timestamp. You can also add optional subject properties such as browser or country.
 
-In this step, you're going to write SQL to pull that data.
+If you do not yet have assignment logs in your warehouse, see the [Event Logging page](/how-tos/event-logging).
 
 ![Write Assignment SQL Query](/img/building-experiments/add-assignment-sql-query.png)
 
@@ -51,20 +50,12 @@ In case there's any ambiguity as to which properties the columns correspond to, 
 
 ![Annotate assignment SQL columns](/img/building-experiments/annotate-assignment-sql-columns.png)
 
-7. Make note of your feature flag name and variant names
-
-Note the value of the **FEATURE FLAG** column; in this example it's `new_user_onboarding` - this is your feature flag name.
-
-Note the values of the **VARIANT** column; in this example it's `control` and `treatment` - these are the names of your variants.
-
-You will need these names later.
-
-8. Adding optional properties
-
-![Add Assignment SQL Properties](/img/building-experiments/add-assignment-sql-dimensions.png)
+7. Adding optional properties
 
 Your feature flag tooling may have logged additional data about the user, like what country they're from or which browser they're using. You can annotate these additional properties here, and they will show up under the **Entity Property SQL** tab.
 
 <!-- <img src="https://firebasestorage.googleapis.com/v0/b/eppo-documentation-images.appspot.com/o/add-assignment-sql-dimensions.png?alt=media&token=dfd583db-4ea7-4013-b5fc-d90612118738" width="500" height="200"/> -->
 
-9. Click **Save & Close**
+![Add Assignment SQL Properties](/img/building-experiments/add-assignment-sql-dimensions.png)
+
+8. Click **Save & Close**


### PR DESCRIPTION
A few minor edits to the Assignment SQL page. This is just to fix confusion around how Assignment SQLs fit in for E2E customers.

I would like to do another pass on all of the definitions pages and replace screenshots with new UI, tidy things up, etc. This PR is just to get some rather misleading things fixed