### PR TITLE
Update docusaurus.config.js - correct footer links to marketing site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,11 +123,11 @@ async function createConfig () {
             items: [
               {
                 label: 'Eppo',
-                to: 'https://geteppo.com'
+                to: 'https://www.geteppo.com'
               },
               {
                 label: 'Blog',
-                to: 'https://geteppo.com/blog'
+                to: 'https://www.geteppo.com/blog'
               },
               {
                 label: 'Eppo application',


### PR DESCRIPTION
Currently, the footer of the Docs site points to "https://geteppo.com", which 301 redirects to "https://www.geteppo.com" - updated to point directly to the canonical version of the URL for SEO purposes