### PR TITLE
Retention metric definition and Bayesian defaults

### DIFF
--- a/docs/data-management/metrics/simple-metric.md
+++ b/docs/data-management/metrics/simple-metric.md
@@ -76,11 +76,15 @@ Examples: videos watched per user, articles viewed per visitor, orders per user.
 
 Retention metrics measure the proportion of entities who have at least one fact value appear after a fixed number of days (X) from experiment assignment. For example, a 7-day retention metric on the website visits fact might measure the proportion of users who visit a website at least 7 days after being assigned to the experiment.
 
-$\frac{\text{Sum of \{1 if a non-null fact value is present X days after the assignment time, else 0, for each unique entity\}}}{\text{Number of unique entities assigned}}$
+$\frac{\text{Sum of \{1 if a non-null fact value is present X days after the assignment time, else 0, for each unique entity assigned at least X days ago\}}}{\text{Number of unique entities assigned at least X days ago}}$
+
+Only entities that were assigned at least $X$ days ago are included in both numerator and denominator. Those assigned within the last $X$ days cannot yet have retained, by construction. For those the numerator is always $0$, and including them would make retention appear artificially low.
 
 For example, if $X = 7 \text{ days}$, Eppo records a retention event for an entity when
 
-$(\text{timestamp of event}) - (\text{timestamp of assignment}) >= 7 \text{ days}$.
+$(\text{timestamp of event}) - (\text{timestamp of assignment}) \geq 7 \text{ days}$
+
+for all entities for which $\text{timestamp of assignment}$ is at least 7 days ago.
 
 #### Conversion
 

--- a/docs/statistics/confidence-intervals/statistical-nitty-gritty.md
+++ b/docs/statistics/confidence-intervals/statistical-nitty-gritty.md
@@ -226,12 +226,12 @@ distribution[^conjugate] as our prior for the lift:
 
 $$
 \begin{equation}
-\hat{\Delta}_{prior} \sim \mathcal{N}(\mu_{prior}=0; ~\sigma_{prior}^2 = 0.1^2)
+\hat{\Delta}_{prior} \sim \mathcal{N}(\mu_{prior}=0; ~\sigma_{prior}^2 = 0.05^2)
 \end{equation}
 $$
 
 In other words, our prior is that the lift, on average, will be zero, with a standard
-deviation of $0.1$. Reach out to us if you want to adjust this default.
+deviation of $0.05$. You can adjust the prior standard deviation in the [Statistical Analysis Plan admin settings](https://eppo.cloud/admin/statistical-analysis-plan) to reflect your prior knowledge of how common or rare large lifts are. This setting is shared across all experiments using Bayesian analysis. (To change the prior standard deviation when Bayesian is not the company default, temporarily make Bayesian the default, change the prior standard deviation, and save; then revert to the previous analysis method.)
 
 [^conjugate]:
     We use a normal distribution because it is a convenient [conjugate

--- a/docs/statistics/confidence-intervals/statistical-nitty-gritty.md
+++ b/docs/statistics/confidence-intervals/statistical-nitty-gritty.md
@@ -155,7 +155,7 @@ $$
 But, since we don't know the true values $\mu_T$ and <NoBreak>$\mu_C$</NoBreak>,
 we'll need to instead _estimate_ the lift. We know from the CLT, as shown in
 equation 3 above, that $m_T$ and $m_C$ are approximately normally
-distributed (for sufficiently large $n_C$ and $n_T$); furthermore, since $m_T$
+distributed (for sufficiently large $n_T$ and $n_C$); furthermore, since $m_T$
 and $m_C$ are independent, under reasonable assumptions the ratio
 $\frac{m_T}{m_C}$ is approximately normal.[^normality2] This allows us to model
 $\hat{\Delta}$ as a normal distribution:
@@ -197,7 +197,7 @@ intervals). For Bayesian, however, there's one more step.
     For more on requirements for this approximation, see note
     [above](#fn-normality). In this case, the denominator (which must be
     unlikely to be negative for the approximation to hold) is the distribution
-    of the treatment metric.
+    of the metric in the control group.
 
 :::info
 
@@ -242,7 +242,7 @@ deviation of $0.05$. You can adjust the prior standard deviation in the [Statist
 
 #### Updating the prior
 
-The evidence from the experiment is construed as a normal distribution
+The evidence from the experiment is constructed as a normal distribution
 $\hat{\Delta}$ just as with the frequentist methods (see equations 2–4 above).
 However, for the Bayesian method we use this evidence to update the above prior,
 and the result is our posterior.


### PR DESCRIPTION
- Updated the description of retention metrics to reflect the changes from [EXP-916](https://linear.app/eppo/issue/EXP-916/[farmers-dog]-improve-retention-and-conversion-metric-calculation) ([Slack context](https://eppo-group.slack.com/archives/C01TTTNMCBB/p1704299072796209))

While I was at it, also
- Updated Bayesian default prior standard deviation, and added instruction on how to change it
- Fixed a few typos in statistical nitty-gritty