### PR TITLE
Minor suggestions

### DIFF
--- a/docs/how-tos/connecting-dwh/bigquery.md
+++ b/docs/how-tos/connecting-dwh/bigquery.md
@@ -41,7 +41,7 @@ TO "serviceAccount:<service_account_name>@<project>.iam.gserviceaccount.com";
 
 ```sql
 GRANT `roles/bigquery.dataViewer`
-ON SCHEMA `<your-project>`.`<your-dataset>`
+ON SCHEMA `<your-project>`.`eppo_output`
 TO "serviceAccount:<service_account_name>@<project>.iam.gserviceaccount.com";
 ```
 

--- a/docs/quick-starts/feature-flag-quickstart.md
+++ b/docs/quick-starts/feature-flag-quickstart.md
@@ -98,7 +98,7 @@ const userAttributes = {
   device: user.device,
 };
 
-const variation = eppoClient.getAssignment(
+const variation = eppoClient.getStringAssignment(
   user.id,
   "new-checkout-page",
   userAttributes


### PR DESCRIPTION
I am suggesting the following minor improvements. Please feel free to disagree.

1. In the instructions for setting up BigQuery, the _eppo_output_ dataset is created in step 1 and referenced as such in step 2 so it makes sense to reference it as such in step 3. 
2. Per [this comment](https://github.com/Eppo-exp/js-client-sdk-common/blob/0898d84072fb22a67ff659be15c2f44e84ea61c6/src/client/eppo-client.ts#L110) in the JS SDK, the _getAssignment_ function has been deprecated so I have replaced it with _getStringAssignment_. We could though instead use  _get < Type > Assignment_ and add a note to explain 'Type' further.