### PR TITLE
Add documentation for new Node and Client JS Initialization Options

### DIFF
--- a/docs/feature-flags/sdks/javascript.md
+++ b/docs/feature-flags/sdks/javascript.md
@@ -74,6 +74,19 @@ API Keys used with Client SDKs should have only 'Feature Flagging READ' permissi
 
 <br />
 
+### Initialization options
+
+How the SDK fetches experiment configurations is configurable via additional initialization options:
+
+| Option | Description | Default |
+| ------ | ----------- | ------- | 
+| **`requestTimeoutMs`** (number) | Timeout in milliseconds for HTTPS requests for the experiment configurations. | `5000` |
+| **`numInitialRequestRetries`** (number) | Number of _additional_ times the initial configurations request will be attempted if it fails. This is the request typically synchronously waited (via `await`) for completion. A small wait will be done between requests. | `1` |
+| **`pollAfterSuccessfulInitialization`** (boolean) | Poll for new configurations (every 30 seconds) after successfully requesting the initial configurations. | `false` |
+| **`pollAfterFailedInitialization`** (boolean) | Poll for new configurations even if the initial configurations request failed. | `false` |
+| **`throwOnFailedInitialization`** (boolean) | Throw an error (reject the promise) if unable to fetch initial configurations during initialization. | `true` |
+| **`numPollRequestRetries`** (number) | If polling for updated configurations after initialization, the number of additional times a request will be attempted before giving up. Subsequent attempts are done using an exponential backoff. | `7` |
+
 ### Define an assignment logger (experiment assignment only)
 
 If you are using the Eppo SDK for experiment assignment (i.e randomization), pass in a callback logging function to the `init` function on SDK initialization. The SDK invokes the callback to capture assignment data whenever a variation is assigned.

--- a/docs/feature-flags/sdks/javascript.md
+++ b/docs/feature-flags/sdks/javascript.md
@@ -76,7 +76,7 @@ API Keys used with Client SDKs should have only 'Feature Flagging READ' permissi
 
 ### Initialization options
 
-How the SDK fetches experiment configurations is configurable via additional initialization options:
+How the SDK fetches experiment configurations is configurable via additional optional initialization options:
 
 | Option | Description | Default |
 | ------ | ----------- | ------- | 

--- a/docs/feature-flags/sdks/node.md
+++ b/docs/feature-flags/sdks/node.md
@@ -46,6 +46,18 @@ await init({
 
 After initialization, the SDK begins polling Eppo’s API at regular intervals to retrieve the most recent experiment configurations such as variation values and traffic allocation. The SDK stores these configurations in memory so that assignments thereafter are effectively instant. If you are using the SDK for experiment assignments, make sure to pass in an assignment logging callback (see [section](#define-an-assignment-logger-experiment-assignment-only) below).
 
+### Initialization options
+
+How the SDK fetches experiment configurations is configurable via additional optional initialization options:
+
+| Option | Description | Default |
+| ------ | ----------- | ------- | 
+| **`requestTimeoutMs`** (number) | Timeout in milliseconds for HTTPS requests for the experiment configurations. | `5000` |
+| **`numInitialRequestRetries`** (number) | Number of _additional_ times the initial configurations request will be attempted if it fails. This is the request typically synchronously waited (via `await`) for completion. A small wait will be done between requests. | `1` |
+| **`pollAfterFailedInitialization`** (boolean) | Poll for new configurations even if the initial configurations request failed. | `false` |
+| **`throwOnFailedInitialization`** (boolean) | Throw an error (reject the promise) if unable to fetch initial configurations during initialization. | `true` |
+| **`numPollRequestRetries`** (number) | If polling for updated configurations after initialization, the number of additional times a request will be attempted before giving up. Subsequent attempts are done using an exponential backoff. | `7` |
+
 ### Define an assignment logger (experiment assignment only)
 
 If you are using the Eppo SDK for experiment assignment (i.e randomization), pass in a callback logging function to the `init` function on SDK initialization. The SDK invokes the callback to capture assignment data whenever a variation is assigned.


### PR DESCRIPTION
🎟️ **Ticket:** [FF-1486 - Update Node and JS Client Docs for new polling options](Update Node and JS Client Docs for new polling options)

The recently released Node JS ([PR](https://github.com/Eppo-exp/node-server-sdk/pull/45)) and Client JS ([PR](https://github.com/Eppo-exp/js-client-sdk/pull/45)) SDKs expose additional optional initialization options for configuring how experiment configurations should be requested. These docs document these.

---

<img width="991" alt="image" src="https://github.com/Eppo-exp/eppo-docs/assets/417605/80827900-38b5-4951-b925-6d1a431734e8">

---

Note that the two are the same, except for the Client JS has a `pollAfterSuccessfulInitialization` option that defaults to `false`, whereas its always `true` for node and not an option.