### PR TITLE
Simpler Get Started Python example

### DIFF
--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -8,9 +8,9 @@ Eppo's Python SDK can be used for both feature flagging and experiment assignmen
 - [GitHub repository](https://github.com/Eppo-exp/python-sdk)
 - [PyPI package](https://pypi.org/project/eppo-server-sdk/)
 
-## Getting started
+## 1. Getting started
 
-### 1. Install the SDK
+### A. Install the SDK
 
 First, install the SDK with PIP:
 
@@ -18,7 +18,7 @@ First, install the SDK with PIP:
 pip install eppo-server-sdk
 ```
 
-### 2. Initialize the SDK
+### B. Initialize the SDK
 
 To initialize the SDK, you will need a SDK key. You can generate one [in the flag interface](https://eppo.cloud/feature-flags/keys).
 
@@ -34,7 +34,7 @@ client = eppo_client.get_instance()
 
 This generates a singleton client instance, that can be reused throughout the application lifecycle
 
-## 3. Assign variations
+### C. Assign variations
 
 This instance can then be called to assigning users to flags or experiments using the `get_string_assignment` function:
 
@@ -52,11 +52,13 @@ elif:
 
 That’s it: You can already start changing the feature flag on the page and see how it controls your code!
 
-## Advanced Configuration
+## 2. Running the SDK
 
-### 1. Loading Configuration
+How is this SDK actually working?
 
-At initialization, the SDK polls Eppo’s API to retrieve the most recent experiment configurations. The SDK stores these configurations in memory so that assignments are effectively instant.
+### A. Loading Configuration
+
+At initialization, the SDK polls Eppo’s API to retrieve the most recent experiment configurations. The SDK stores these configurations in memory. This is why assignments are effectively instant.
 
 :::note
 
@@ -64,19 +66,21 @@ Your users’ private information doesn’t leave your servers. Eppo only stores
 
 :::
 
-### 2. Automatical Updating the SDK
+### B. Automatical Updating the SDK
 
-After initialization, the SDK continues polling Eppo’s API at 30-second intervals, to retrieve the most recent experiment configurations such as variation values and traffic allocation. 
+After initialization, the SDK continues polling Eppo’s API at 30-second intervals. This retrieves the most recent experiment configurations such as variation values and traffic allocation.
 
 :::note
 
-It may take up to 30 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
+Changes made to experiments on Eppo’s web interface are almost instantly propagated through our CDN network. But because of the refresh rate, it may take up to 30 seconds for those to be reflected by the SDK assignments.
 
 :::
 
-### 3. Define an Assignment Logger (Experiment Assignment Only)
+## 3. Good practices 
 
-If you are using the Eppo SDK for experiment assignment (i.e., randomization), we will need to know which entity, typically which user, was exposed to the experiment. For that, we need to log that information. We recommend you pass a **callback logging** function when initializing the SDK. Whenever a variation is assigned, the client instance will invoke that callback, capturing assignment data.
+### A. Define an Assignment Logger (Experiment Assignment Only)
+
+If you are using the Eppo SDK for experiment assignment (i.e., randomization), we will need to know which entity, typically which user, passed through an Entry point and was exposed to the experiment. For that, we need to log that information. We recommend that you pass a **callback logging** function when initializing the SDK. Whenever a variation is assigned, the client instance will invoke that callback, capturing assignment data.
 
 The code below illustrates an example implementation of a logging callback using Segment. You could also use your own logging system, the only requirement is that the SDK receives a `log_assignment` function.
 
@@ -114,9 +118,28 @@ The SDK will invoke the `log_assignment` function with an `assignment` object th
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{ "country": "US" }`               |
 | `featureFlag` (string)    | An Eppo feature flag key                                                                                                 | "recommendation-algo"               |
 | `allocation` (string)     | An Eppo allocation key                                                                                                   | "allocation-17"                     |
+### B. Handling `None`
+
+To be safe, we recommend always handling the `None` case in your code. Here are some examples illustrating when the SDK might return `None`:
+
+1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `None` for the remaining 75% (unless the subject is part of an allow list).
+
+2. Assignments occur within the environments of feature flags. You must **enable the environment** corresponding to the feature flag’s allocation in the [flag control pannel](https://eppo.cloud/feature-flags/) before `getStringAssignment` returns variations. It will return `None` if the environment is not enabled.
+
+![Toggle to enable environment](/static/img/feature-flagging/enable-environment.png)
+
+3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `None` if no configurations have been downloaded.
+
+:::info
+
+By default the Eppo client initialization is asynchronous to ensure no critical code paths are blocked. For more information on handling non-blocking initialization, see our [documentation here](/feature-flagging/common-issues#3-not-handling-non-blocking-initialization).
+
+:::
 
 
-### 1. Assign Variations with Metadata
+## 4. Advanced Configuration
+
+### A. Assign Variations with Metadata
 
 When assigning entities, you can pass metadata through a dictionary of properties:
 
@@ -138,9 +161,9 @@ We introduced `get_string_assignment`’s two required inputs in the [Getting st
      user_agent:"Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",}`  
   If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call. 
 
-### 2. Typed Assignments
+### B. Typed Assignment Calls
 
-The SDK also offers assignment calls for other assignment types. They take the same inputs: `subjectKey`, `flagOrExperimentKey` and `targetingAttributes`.
+The SDK also offers assignment calls for other assignment types.
 
 ```
 get_boolean_assignment(...)
@@ -149,20 +172,4 @@ get_json_string_assignment(...)
 get_parsed_json_assignment(...)
 ```
 
-### 3. Handling `None`
-
-To be safe, we recommend always handling the `None` case in your code. Here are some examples illustrating when the SDK might return `None`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `None` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must **enable the environment** corresponding to the feature flag’s allocation in the [flag control pannel](https://eppo.cloud/feature-flags/) before `getStringAssignment` returns variations. It will return `None` if the environment is not enabled.
-
-![Toggle to enable environment](/static/img/feature-flagging/enable-environment.png)
-
-3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `None` if no configurations have been downloaded.
-
-:::info
-
-By default the Eppo client initialization is asynchronous to ensure no critical code paths are blocked. For more information on handling non-blocking initialization, see our [documentation here](/feature-flagging/common-issues#3-not-handling-non-blocking-initialization).
-
-:::
+Those take the same input as `get_string_assignment`: `subjectKey`, `flagOrExperimentKey` and `targetingAttributes`.

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -237,10 +237,10 @@ if request.method == 'POST':
 		country = g.city(ip)["country_code"]
 
     session_attributes = {
-	'country': country,
-	'loyalty_tier': request.session.loyalty_tier,
-	'browser_type': request.user_agent.browser.family,
-	'device_type': request.user_agent.device.family,
+        'country': country,
+        'loyalty_tier': request.session.loyalty_tier,
+        'browser_type': request.user_agent.browser.family,
+        'device_type': request.user_agent.device.family,
     }
 
     variation = client.get_string_assignment(

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -195,7 +195,7 @@ To be safe, we recommend always handling the `None` case in your code. Here are 
 
 2. Assignments occur within the environments of feature flags. You must **enable the environment** corresponding to the feature flag’s allocation in the [flag control pannel](https://eppo.cloud/feature-flags/) before `getStringAssignment` returns variations. It will return `None` if the environment is not enabled.
 
-![Toggle to enable environment](/static/img/feature-flagging/enable-environment.png)
+![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
 
 3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `None` if no configurations have been downloaded.
 

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -33,7 +33,7 @@ client = eppo_client.get_instance()
 …
 ```
 
-This generates a singleton client instance, that can be reused throughout the application lifecycle
+This generates a singleton client instance that can be reused throughout the application lifecycle
 
 ### C. Assign variations
 

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -214,7 +214,7 @@ Those can be used by the feature flag or the experiement for targeting, through 
 
 ### B. Example Payment Configuration
 
-Let’s say you are running a Django service with the User-Agent package. You want to use feature flags to offer payment method that adapt to the browser (only Safari users should be offered to user ApplePay) and the country (so that Dutch users can use iDEAL) and members of your loyalty program might use their points. You can use a feature flag to configure what is possible in which country, for which users, etc. 
+Let’s say you are running a Django service with the User-Agent package. You want to use feature flags to offer payment method that adapt to the browser (only Safari users should be offered to use ApplePay) and the country (so that Dutch users can use iDEAL) and members of your loyalty program might use their points. You can use a feature flag to configure what is possible in which country, for which users, etc. 
 
 To make the decision, you can put the relevant information (`country`, `loyalty_tier`, etc.) in a `session_attributes` dictionary:
 

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -8,39 +8,86 @@ Eppo's Python SDK can be used for both feature flagging and experiment assignmen
 - [GitHub repository](https://github.com/Eppo-exp/python-sdk)
 - [PyPI package](https://pypi.org/project/eppo-server-sdk/)
 
-## 1. Install the SDK
+## Getting started
 
-Install the SDK with PIP:
+### 1. Install the SDK
+
+First, install the SDK with PIP:
 
 ```bash
 pip install eppo-server-sdk
 ```
 
-## 2. Initialize the SDK
+### 2. Initialize the SDK
 
-Initialize the SDK with a SDK key, which can be generated in the Eppo interface. Initialization the SDK when your application starts up to generate a singleton client instance, once per application lifecycle:
+To initialize the SDK, you will need a SDK key. You can generate one [in the flag interface](https://eppo.cloud/feature-flags/keys).
 
 ```python
 import eppo_client
 from eppo_client.config import Config
 
-client_config = Config(api_key="<YOUR_API_KEY>", assignment_logger=AssignmentLogger())
+client_config = Config(api_key="<YOUR_API_KEY>")
 eppo_client.init(client_config)
+client = eppo_client.get_instance()
+…
 ```
 
-After initialization, the SDK begins polling Eppo’s API at regular intervals to retrieve the most recent experiment configurations such as variation values and traffic allocation. The SDK stores these configurations in memory so that assignments are effectively instant. If you are using the SDK for experiment assignments, make sure to pass in an assignment logging callback (see [section](#define-an-assignment-logger-experiment-assignment-only) below).
+This generates a singleton client instance, that can be reused throughout the application lifecycle
 
-:::info
+## 3. Assign variations
 
-By default the Eppo client initialization is asynchronous to ensure no critical code paths are blocked. For more information on handling non-blocking initialization, see our [documentation here](/feature-flagging/common-issues#3-not-handling-non-blocking-initialization).
+This instance can then be called to assigning users to flags or experiments using the `get_string_assignment` function:
+
+```python
+…
+variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>")
+if variation = "fast_checkout":
+    …
+elif:
+    …
+```
+
+* `<SUBJECT-KEY>` is the value if the, typically `user_id`
+* `<FLAG-OR-EXPERIMENT-KEY>` is the key that you chose when creating a flag; you can find it on the [flag page](https://eppo.cloud/feature-flags).
+
+That’s it: You can already start changing the feature flag on the page and see how it controls your code!
+
+## Advanced Configuration
+
+### 1. Loading Configuration
+
+At initialization, the SDK polls Eppo’s API to retrieve the most recent experiment configurations. The SDK stores these configurations in memory so that assignments are effectively instant.
+
+:::note
+
+Your users’ private information doesn’t leave your servers. Eppo only stores your flag and experiment configurations.
 
 :::
 
-### Define an assignment logger (experiment assignment only)
+### 2. Automatical Updating the SDK
 
-If you are using the Eppo SDK for experiment assignment (i.e randomization), pass in a callback logging function to the `init` function on SDK initialization. The SDK invokes the callback to capture assignment data whenever a variation is assigned.
+After initialization, the SDK continues polling Eppo’s API at 30-second intervals, to retrieve the most recent experiment configurations such as variation values and traffic allocation. 
 
-The code below illustrates an example implementation of a logging callback using Segment. You could also use your own logging system, the only requirement is that the SDK receives a `log_assignment` function. Here we define an implementation of the Eppo `IAssignmentLogger` interface containing a single function named `log_assignment`:
+:::note
+
+It may take up to 30 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
+
+:::
+
+### 3. Define an Assignment Logger (Experiment Assignment Only)
+
+If you are using the Eppo SDK for experiment assignment (i.e., randomization), we will need to know which entity, typically which user, was exposed to the experiment. For that, we need to log that information. We recommend you pass a **callback logging** function when initializing the SDK. Whenever a variation is assigned, the client instance will invoke that callback, capturing assignment data.
+
+The code below illustrates an example implementation of a logging callback using Segment. You could also use your own logging system, the only requirement is that the SDK receives a `log_assignment` function.
+
+:::note
+
+More details about logging and examples (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/sdks/event-logging/) page.
+
+:::
+
+
+Here we define an implementation of the Eppo `IAssignmentLogger` interface containing a single function named `log_assignment`:
 
 ```python
 from eppo_client.assignment_logger import AssignmentLogger
@@ -48,6 +95,8 @@ import analytics
 
 # Connect to Segment (or your own event-tracking system)
 analytics.write_key = "<SEGMENT_WRITE_KEY>"
+
+client_config = Config(api_key="<YOUR_API_KEY>", assignment_logger=AssignmentLogger())
 
 class SegmentAssignmentLogger(AssignmentLogger):
 	def log_assignment(self, assignment):
@@ -66,16 +115,13 @@ The SDK will invoke the `log_assignment` function with an `assignment` object th
 | `featureFlag` (string)    | An Eppo feature flag key                                                                                                 | "recommendation-algo"               |
 | `allocation` (string)     | An Eppo allocation key                                                                                                   | "allocation-17"                     |
 
-:::note
-More details about logging and examples (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/sdks/event-logging/) page.
-:::
 
-## 3. Assign variations
+### 1. Assign Variations with Metadata
 
-Assigning users to flags or experiments with a single `get_string_assignment` function:
+When assigning entities, you can pass metadata through a dictionary of properties:
 
 ```python
-import eppo_client
+…
 
 client = eppo_client.get_instance()
 variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>", {
@@ -83,15 +129,18 @@ variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-K
 })
 ```
 
-The `get_string_assignment` function takes two required and one optional input to assign a variation:
+We introduced `get_string_assignment`’s two required inputs in the [Getting started](#getting-started) section. The function also takes an optional input to assign targetted variation:
 
-- `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
-- `targetingAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+- `subjectKey`: The Entity ID that is being experimented on, typically represented by a uuid.
+- `flagOrExperimentKey`: This key is available on the detail page for both flags and experiments.
+- `targetingAttributes`: An optional map of metadata about the subject used for targeting, for example:  
+  `{country:"Andorra", loyalty: "Gold", browser_type:"Mozilla", device_type: "Macintosh",
+     user_agent:"Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",}`  
+  If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call. 
 
-### Typed assignments
+### 2. Typed Assignments
 
-Additional functions are available:
+The SDK also offers assignment calls for other assignment types. They take the same inputs: `subjectKey`, `flagOrExperimentKey` and `targetingAttributes`.
 
 ```
 get_boolean_assignment(...)
@@ -100,20 +149,20 @@ get_json_string_assignment(...)
 get_parsed_json_assignment(...)
 ```
 
-### Handling `None`
+### 3. Handling `None`
 
-We recommend always handling the `None` case in your code. Here are some examples illustrating when the SDK returns `None`:
+To be safe, we recommend always handling the `None` case in your code. Here are some examples illustrating when the SDK might return `None`:
 
 1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `None` for the remaining 75% (unless the subject is part of an allow list).
 
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `None` if the environment is not enabled.
+2. Assignments occur within the environments of feature flags. You must **enable the environment** corresponding to the feature flag’s allocation in the [flag control pannel](https://eppo.cloud/feature-flags/) before `getStringAssignment` returns variations. It will return `None` if the environment is not enabled.
 
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
+![Toggle to enable environment](/static/img/feature-flagging/enable-environment.png)
 
-3. If `get_string_assignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `None` if no configurations have been downloaded.
+3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `None` if no configurations have been downloaded.
 
-<br />
+:::info
 
-:::note
-It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
+By default the Eppo client initialization is asynchronous to ensure no critical code paths are blocked. For more information on handling non-blocking initialization, see our [documentation here](/feature-flagging/common-issues#3-not-handling-non-blocking-initialization).
+
 :::

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -41,7 +41,7 @@ This instance can then be called to assign users to flags or experiments using t
 
 ```python
 …
-variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-OR-EXPERIMENT-KEY>")
+variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-KEY>")
 if variation == "fast_checkout":
     …
 else:

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -168,7 +168,7 @@ Your users’ private information doesn’t leave your servers. Eppo only stores
 
 :::
 
-### B. Automatical Updating the SDK Configuration
+### B. Automatically Updating the SDK Configuration
 
 After initialization, the SDK continues polling Eppo’s API at 30-second intervals. This retrieves the most recent flag and experiment configurations such as variation values, targeting rules, and traffic allocation. This happens independently of assignment calls.
 

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -294,7 +294,7 @@ If you want to modify a quantity, say, the number of columns of your layout, the
 
 ### C. Parsed JSon Assignment
 
-A more interesting pattern is to assign a JSon object. This allows to include structured information, say the text of a marketing copy for a promotional campaign, and the address of a hero image. Thanks to this pattern, one developer can configure a very simple landing page; with that in place, whoever has access to the Feature flag configuration can decide and change what copy to show to users throughout a promotional period, without them having to release new code.
+A more interesting pattern is to assign a JSON object. This allows to include structured information, say the text of a marketing copy for a promotional campaign, and the address of a hero image. Thanks to this pattern, one developer can configure a very simple landing page; with that in place, whoever has access to the Feature flag configuration can decide and change what copy to show to users throughout a promotional period, without them having to release new code.
 
 ```python
 …

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -36,7 +36,7 @@ This generates a singleton client instance, that can be reused throughout the ap
 
 ### C. Assign variations
 
-This instance can then be called to assigning users to flags or experiments using the `get_string_assignment` function:
+This instance can then be called to assign users to flags or experiments using the `get_string_assignment` function:
 
 ```python
 …

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -68,7 +68,7 @@ Your users’ private information doesn’t leave your servers. Eppo only stores
 
 ### B. Automatical Updating the SDK
 
-After initialization, the SDK continues polling Eppo’s API at 30-second intervals. This retrieves the most recent experiment configurations such as variation values and traffic allocation.
+After initialization, the SDK continues polling Eppo’s API at 30-second intervals. This retrieves the most recent experiment configurations such as variation values, targeting rules, and traffic allocation.
 
 :::note
 

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -110,13 +110,13 @@ You can check that the local logging file `eppo_assignments.csv` contains all th
 
 | Field                     | Description                                                                                                              | Example                             |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
-| `experiment` (string)     | An Eppo experiment key                                                                                                   | `"new_faster_checkout"` |
+| `experiment` (string)     | An Eppo experiment key                                                                                                   | `"checkout_type-allocation-1234"` |
 | `subject` (string)        | An identifier of the subject or user assigned to the experiment variation                                                | `"60a67ae2-c9d2-4f8a-9be0-3bb4fe0c96ff"`|
-| `variation` (string)      | The experiment variation the subject was assigned to                                                                     | `"treatment"`                           |
+| `variation` (string)      | The experiment variation the subject was assigned to                                                                     | `"fast_checkout"`                           |
 | `timestamp` (string)      | The time when the subject was assigned to the variation                                                                  | `2021-06-22T17:35:12.000Z`            |
 | `subjectAttributes` (map) | A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function | `{}`               |
 | `featureFlag` (string)    | An Eppo feature flag key                                                                                                 | `"checkout_type"`              |
-| `allocation` (string)     | An Eppo allocation key                                                                                                   | `"fast_checkout"`                     |
+| `allocation` (string)     | An Eppo allocation key                                                                                                   | `"allocation-1234"`                     |
 
 If you implemented it that way in production, you would need to upload that assignment file to your database. That’s not very convenient. Instead, we recommend you use your usual on-line logging service to do so.
 
@@ -132,7 +132,7 @@ More details about logging and examples (with Segment, Rudderstack, mParticle, a
 
 :::
 
-Here we define an implementation of the Eppo `AssignmentLogger` interface containing a single function named `log_assignment`:
+
 
 ```python
 from eppo_client.assignment_logger import AssignmentLogger
@@ -151,7 +151,7 @@ client_config = Config(api_key="<YOUR_API_KEY>",
 …
 ```
 
-The SDK will invoke the `log_assignment` function with an `assignment` object that contains the fields you've seem locally. Make sure the dictionnary is parse properly by your tooling.
+The SDK will invoke the `log_assignment` function with an `assignment` object that contains the fields you've seen locally. Make sure the dictionnary is parse properly by your tooling.
 
 
 ## 3. Running the SDK
@@ -167,6 +167,8 @@ At initialization, the SDK polls Eppo’s API to retrieve the most recent experi
 Your users’ private information doesn’t leave your servers. Eppo only stores your flag and experiment configurations.
 
 :::
+
+For more information on the performance of Eppo's SDKs, see the [latency](/sdks/faqs/latency) and [risk](/sdks/faqs/risk) pages.
 
 ### B. Automatically Updating the SDK Configuration
 
@@ -188,7 +190,7 @@ To be safe, we recommend always handling the `None` case in your code. Here are 
 
 ![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
 
-3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `None` if no configurations have been downloaded.
+3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will return `None`.
 
 :::info
 
@@ -208,17 +210,17 @@ But that’s not all: the function also takes an optional input for entity prope
 
 ### A. Optional Properties for Targetting 
 
-Most entities on which we run feature flags have properties: sessions have browser types, users have loyalty status, corporate clients have a number of employees, videos have close-caption available or not, sport teams have a league, etc. If you want to decide how a feature flag behaves, or whether an experiment is ran on a certain entity based on those, you need to send that information too. When assigning entities, you can pass that additional information through:
+Most entities on which we run feature flags have properties: sessions have browser types, users have loyalty status, corporate clients have a number of employees, videos have close-caption available or not, sport teams have a league, etc. If you want to decide how a feature flag behaves, or whether an experiment is ran on a certain entity based on those, you need to send that information too. When assigning entities, you can pass that additional information through `subject_attributes`: an optional dictionnary that details entity properties. 
 
-- `subject_attributes`: An optional dictionnary that details entity properties; for example, if the entity is a customer session:  
+For example, if the entity is a customer session ,`subject_attributes` might look like this:  
   `{country:"Andorra", loyalty:"Gold", browser_type:"Mozilla", device_type:"Macintosh",
      user_agent:"Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",}`
 
-Those can be used by the feature flag or the experiement for targeting, through the **Allocations** setting on the configuration page.
+Those can be used by the feature flag or the experiment for targeting, through the **Allocations** setting on the configuration page.
 
 ### B. Example Payment Configuration
 
-Let’s say you are running a Django service with the User-Agent package. You want to use feature flags to offer payment method that adapt to the browser (only Safari users should be offered to use ApplePay) and the country (so that Dutch users can use iDEAL) and members of your loyalty program might use their points. You can use a feature flag to configure what is possible in which country, for which users, etc. 
+Let’s say you are running a Django service with the User-Agent package. You want to use feature flags to offer a payment method that adapt to the browser (only Safari users should be offered to use ApplePay), the country (Dutch users can use iDEAL), and loyalty status (members might use their points). You can use a feature flag to configure what is possible in which country, for which users, etc. 
 
 To make the decision, you can put the relevant information (`country`, `loyalty_tier`, etc.) in a `session_attributes` dictionary:
 
@@ -245,7 +247,7 @@ if request.method == 'POST':
 
     variation = client.get_string_assignment(
         "<SUBJECT-KEY>",
-        "<FLAG-OR-EXPERIMENT-KEY>",
+        "<FLAG-KEY>",
         session_attributes,
     )
     
@@ -257,7 +259,7 @@ if request.method == 'POST':
 	…
 ```
 
-Our approach is more flexible: it lets you configure properties that match the relevant entity for your feature flag or your experiments. For example, if a user is usually on iOS but they are connecting from a PC browser this time, they probably should not be offered an ApplePay option, in spite of being labelled an iOS user.
+Our approach is highly flexible: it lets you configure properties that match the relevant entity for your feature flag or experiment. For example, if a user is usually on iOS but they are connecting from a PC browser this time, they probably should not be offered an ApplePay option, in spite of being labelled an iOS user.
 
 :::note
 
@@ -290,15 +292,15 @@ else:
     …
 ```
 
-That prevents having the option of a third output. However, “True” can be ambiguous when the allocation names are unclear, like `hide_vs_delete_spam` or `no_collapse_price_breakdown`. We would recommend sticking to string that offer more explicit naming convention: `keep_and_hide_spam`, `delete_spam`, or `collapse_price_breakdown`, `expand_price_breakdown` and `delete_price_breakdown`.
+That prevents having the option of a third output. However, “True” can be ambiguous when the allocation names are unclear, like `hide_vs_delete_spam` or `no_collapse_price_breakdown`. We would recommend sticking to strings that offer more explicit naming convention: `keep_and_hide_spam`, `delete_spam`, or `collapse_price_breakdown`, `expand_price_breakdown` and `delete_price_breakdown`.
 
 ### B. Numeric Assignment
 
-If you want to modify a quantity, say, the number of columns of your layout, the number of product recommendations per page or the minimum spent for free delivery, you want to make sure the allocation value is a number. Using a numeric assignement and the call `get_numeric_assignment` guarantees that. When someone edit the assignment, it will remain a number. This is useful if you are using that value in computation, say to process the amount of a promotion. It will not validate obvious configuration issues before they are rolled-out.
+If you want to modify a quantity, say, the number of columns of your layout, the number of product recommendations per page or the minimum spent for free delivery, you want to make sure the allocation value is a number. Using a numeric-valued flag and `get_numeric_assignment` guarantees that. When someone edits the assignment, it will remain a number. This is useful if you are using that value in computation, say to process the amount of a promotion. It will capture obvious configuration issues before they are rolled-out.
 
-### C. Parsed JSon Assignment
+### C. Parsed JSON Assignment
 
-A more interesting pattern is to assign a JSON object. This allows to include structured information, say the text of a marketing copy for a promotional campaign, and the address of a hero image. Thanks to this pattern, one developer can configure a very simple landing page; with that in place, whoever has access to the feature flag configuration can decide and change what copy to show to users throughout a promotional period, almost instantly and without them having to release new code.
+A more interesting pattern is to assign a JSON object. This allows us to include structured information, say the text of a marketing copy for a promotional campaign and the address of a hero image. Thanks to this pattern, one developer can configure a very simple landing page; with that in place, whoever has access to the feature flag configuration can decide and change what copy to show to users throughout a promotional period, almost instantly and without them having to release new code.
 
 ```python
 …
@@ -311,8 +313,8 @@ if self.campaign_json is not None:
 …
 ```
 
-Assuming your service can be configured with many input parameters, that assignment type enables very powerful configuration changes. It does come with more risk of using the wrong key or value, so you probably want to explore ways to type check your variations.
+Assuming your service can be configured with many input parameters, that assignment type enables very powerful configuration changes.
 
-### D. String JSon Assignment
+### D. String JSON Assignment
 
-`get_json_string_assignment` is similar, but the output is a string. This adds the responsability of unpacking the JSon from that string.
+`get_json_string_assignment` is similar, but the output is a string. This adds the responsability of unpacking the JSON from that string.


### PR DESCRIPTION
A more straightforward write-up of getting the Python SDK running, splitting the advanced configuration into a separate section.

More work is needed to give code examples for advanced set-up.