### PR TITLE
Fix typos in feature flagging section

### DIFF
--- a/docs/data-management/index.md
+++ b/docs/data-management/index.md
@@ -21,7 +21,7 @@ For example, if you are a food delivery app, and you want to run experiments on 
 
 ### Annotating tables
 
-There are three core tables that Eppo needs to know about to successfully analyze expeirments
+There are three core tables that Eppo needs to know about to successfully analyze experiments.
 
 - Assignment tables: which subjects participated in experiments and what variants did they see?
 - Fact tables: what actions did subjects take, so we can turn them into metrics?

--- a/docs/feature-flagging/experiment-assignment.md
+++ b/docs/feature-flagging/experiment-assignment.md
@@ -20,6 +20,6 @@ Click "Create Experiment" on the experiment allocation to create an experiment. 
 
 ![Randomization 1](/img/feature-flagging/randomization-1.png)
 
-Once assignments have begun, they will need to be logged to your data warehouse to be analyzed by Eppo. All SDKs take in a callback function that is called with the assignment parameters (`subject_id`, `experiment_id`, `timestamp`, etc.) passed in when assignment are made. That function is completely managed by you - the only requirement is that the assignment data eventually makes it to your warehouse. 
+Once assignments have begun, they will need to be logged to your data warehouse to be analyzed by Eppo. All SDKs take in a callback function that is called with the assignment parameters (`subject_id`, `experiment_id`, `timestamp`, etc.) passed in when assignments are made. That function is completely managed by you - the only requirement is that the assignment data eventually makes it to your warehouse. 
 
-Congratulations on setting up your first Eppo randomized experiment! Refer to our analysis set up guide to connect Eppo to your data warehouse and easily analyze the results.
+Congratulations on setting up your first Eppo randomized experiment! Refer to our [analysis setup guide](/experiment-quickstart) to connect Eppo to your data warehouse and easily analyze the results.

--- a/docs/feature-flagging/experiment-assignment.md
+++ b/docs/feature-flagging/experiment-assignment.md
@@ -16,7 +16,7 @@ Your flag must be active to start the experiment assignment.
 
 ### Create an experiment
 
-Click "Create Expeirment" on the experiment allocation to create an experiment. You can do this at any time, even after experiment assignment has begun.
+Click "Create Experiment" on the experiment allocation to create an experiment. You can do this at any time, even after experiment assignment has begun.
 
 ![Randomization 1](/img/feature-flagging/randomization-1.png)
 


### PR DESCRIPTION
A few minor fixes while I was reading through the feature flags documentation (+ one more I caught by searching)