### PR TITLE
Changed confidence level to significance level

### DIFF
--- a/docs/guides/non-inferiority-tests.md
+++ b/docs/guides/non-inferiority-tests.md
@@ -6,7 +6,7 @@ This How To guide walks you through how to run non-inferiority tests in Eppo. Th
 
 For this guide, we assume that the way you run the non-inferiority analysis is by running a one-sided hypothesis test on whether the impact is at worst $-c$%, where $c>0$ is your inferiority tolerance. The closer $c$ it is to $0$, the stricter your test is; basically you need stronger evidence of before you call a test non-harmful.
 
-The **left endpoint of the confidence interval in Eppo** has the same information as the non-inferiority test at **half the confidence level ($\alpha$)**.
+The **left endpoint of the confidence interval in Eppo** has the same information as the non-inferiority test at **half the significance level ($\alpha$)**.
 - To perform the test in Eppo, visually check that the left side of the confidence interval is higher than your non-inferiority tolerance. If it's higher than the tolerance, then you can call the experiment non-harmful. If it's lower than the tolerance, then you don't have enough data to call it non-harmful.
   - If the right endpoint is lower than $0$, then you can say the test is harmful. Note that with a permissive tolerance and high statistical power, both of these may happen at the same time!
   - For metrics where lower is better, flip everything above. You'll compare the right endpoint to a threshold above 0.


### PR DESCRIPTION
We have a line where we call `\alpha` the "confidence level" rather than the "significance level." This confused me at first because typically the "confidence level" refers to `1 - \alpha`.  For example, a confidence level of 95% corresponds to `\alpha`=0.05. See terminology in https://en.wikipedia.org/wiki/Statistical_significance