### PR TITLE
Add Bandit Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 
 # Local settings
 .vscode/
+.idea/

--- a/docs/sdks/sdk-features/bandits.md
+++ b/docs/sdks/sdk-features/bandits.md
@@ -1,0 +1,148 @@
+# Contextual multi-armed Bandits
+
+The SDKs also provide functionality for getting an assignment from a contextual multi-armed bandit.
+
+## Background
+
+Contextual multi-armed bandits use reinforcement learning to adjust the frequency it serves an action from a set provided
+to the SDK.
+They use the attributes of the subject and assigned action to form a context for the assignment, and they also have a 
+metric (set in the Eppo application) that it is optimizing for.
+
+Every 24 hours, the bandit looks at the previous 30 days for changes in the optimization metric for subjects who were given
+assignments. It uses the assignment context and metric data to build a model for using context to optimally balance 
+"exploring" other actions or "exploiting" the action the data suggests performs the best for a given context.
+
+Bandits are a special type of dynamic variation, whose value depends on the action the bandit selects. Note that for users
+assigned the bandit variation, the action they receive may change as the bandit model parameters are updated. All actions
+are strings, so bandits are used with string-typed flags. Actions and attributes are case-sensitive.
+
+## Requesting a bandit assignment
+
+When requesting an assignment from a flag with a bandit, the set of actions and their attributes are provided as an
+additional argument to `getStringAssignment()`.
+
+For example, in the Java SDK, the call may look like:
+
+```java
+// Flag that has a bandit variation
+String banditTestFlagKey = "bandit-test";
+
+// Subject information--same as for retrieving simple flag or experiment assignments
+String subjectKey = username;
+EppoAttributes subjectAttributes = userAttributes;
+
+// Action set for bandits
+Map<String, EppoAttributes> actionsWithAttributes = Map.of(
+  "dog", new EppoAttributes(Map.of(
+    "legs": EppoValue.of(4),
+    "size": "large"
+  )),
+  "cat", new EppoAttributes(Map.of(
+    "legs": EppoValue.of(4),
+    "size": "medium"
+  )),
+  "bird", new EppoAttributes(Map.of(
+    "legs": EppoValue.of(2),
+    "size": "medium"
+  )),
+  "goldfish", new EppoAttributes(Map.of(
+    "legs": EppoValue.of(0),
+    "size": "small" 
+  ))   
+);
+
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
+```
+
+If the actions don't have attributes for the context, you can simply provide a set of actions without attributes:
+
+```java
+Set<String> actions = Set.of("dog", "cat", "bird", "goldfish");
+
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actions);
+```
+
+## Logging bandit assignments
+
+Additional information regarding a bandit assignment needs to be logged to the data warehouse to support training the 
+bandit so that it can learn over time. Bandit assignments are logged separately from variation assignments, and require
+an additional bandit assignment logger to be provided.
+
+This logger should write to a table with the following columns (they can be in any order):
+* `timestamp` - Timestamp of the bandit assignment
+* `key` - The key (unique identifier) of the bandit
+* `subject` - The unique identifier for the subject being assigned
+* `subject_numeric_attributes` - Mapping of attribute names to numbers, in JSON format, for the numeric-valued attributes of the subject
+* `subject_categorical_attributes` - Mapping of attribute names to strings, in JSON format, for the non-numeric-valued attributes of the subject
+* `action` - The action assigned by the bandit
+* `action_numeric_attributes` - Mapping of attribute names to numbers, in JSON format, for the numeric-valued attributes of the assigned action
+* `action_categorical_attributes` - Mapping of attribute names to strings, in JSON format, for the non-numeric-valued attributes of the assigned action
+
+Additional information that is provided to the logger that can optionally--but is recommended--be logged includes:
+* `experiment` - The name of the experiment
+* `action_probability` - The probability (weight) given to the assigned action at the time of assignment
+* `model_verison` - The current version identifier of the model used to determine action weights 
+
+Below is an example bandit assignment logger for the Java SDK, defined when building the SDK client, that writes to Snowflake:
+
+```java
+.banditLogger(banditLogData -> {
+    String sql = "INSERT INTO bandit_assignments " +
+      "(timestamp, experiment, variation_value, subject," +
+      " action, action_probability, model_version," +
+      " subject_numeric_attributes, subject_categorical_attributes," +
+      " action_numeric_attributes, action_categorical_attributes) " +
+      "SELECT ?, ?, ?, ?," +
+      " ?, ?, ?," +
+      " parse_json(?), parse_json(?)," +
+      " parse_json(?), parse_json(?)";
+
+    try (PreparedStatement statement = snowflakeConnection.prepareStatement(sql)) {
+      statement.setTimestamp(1, new Timestamp(banditLogData.timestamp.getTime()));
+      statement.setString(2, banditLogData.experiment);
+      statement.setString(3, banditLogData.banditKey);
+      statement.setString(4, banditLogData.subject);
+      statement.setString(5, banditLogData.action);
+      statement.setDouble(6, banditLogData.actionProbability);
+      statement.setString(7, banditLogData.modelVersion);
+      if (banditLogData.subjectNumericAttributes == null) {
+        statement.setNull(8, Types.NULL);
+      } else {
+        statement.setString(8, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.subjectNumericAttributes));
+      }
+      if (banditLogData.subjectCategoricalAttributes == null) {
+        statement.setNull(9, Types.NULL);
+      } else {
+        statement.setString(9, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.subjectCategoricalAttributes));
+      }
+      if (banditLogData.actionNumericAttributes == null) {
+        statement.setNull(10, Types.NULL);
+      } else {
+        statement.setString(10, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.actionNumericAttributes));
+      }
+      if (banditLogData.actionNumericAttributes == null) {
+        statement.setNull(11, Types.NULL);
+      } else {
+        statement.setString(11, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.actionCategoricalAttributes));
+      }
+
+      statement.executeUpdate();
+    } catch (SQLException e) {
+      throw new RuntimeException("Unable to log bandit assignment "+e.getMessage(), e);
+    }
+})
+```
+
+### Logging non-bandit assignments 
+
+If the control variation (i.e., not the bandit) was assigned, but the control variation still resulted in an action being
+assigned via some other mechanism, the bandit can still learn from this non-bandit assignment.
+
+To record this event, you can use the `logNonBanditAction()` method.
+
+In Java, this would look like:
+
+```java
+logNonBanditAction(subjectKey, flagKey, subjectAttributes, action, actionAttributes);
+```

--- a/docs/sdks/sdk-features/bandits.md
+++ b/docs/sdks/sdk-features/bandits.md
@@ -35,22 +35,21 @@ EppoAttributes subjectAttributes = userAttributes;
 // Action set for bandits
 Map<String, EppoAttributes> actionsWithAttributes = Map.of(
   "dog", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(4),
-    "size": "large"
-  )),
+  "legs", EppoValue.valueOf(4),
+  "size", EppoValue.valueOf("large")
+)),
   "cat", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(4),
-    "size": "medium"
-  )),
+  "legs", EppoValue.valueOf(4),
+  "size", EppoValue.valueOf("medium")
+)),
   "bird", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(2),
-    "size": "medium"
-  )),
+  "legs", EppoValue.valueOf(2),
+  "size", EppoValue.valueOf("medium")
+)),
   "goldfish", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(0),
-    "size": "small" 
-  ))   
-);
+  "legs", EppoValue.valueOf(0),
+  "size", EppoValue.valueOf("small")
+))
 
 Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
 ```
@@ -87,7 +86,7 @@ Additional information that is provided to the logger that can optionally--but i
 Below is an example bandit assignment logger for the Java SDK, defined when building the SDK client, that writes to Snowflake:
 
 ```java
-.banditLogger(banditLogData -> {
+.banditLogger(logData -> {
     String sql = "INSERT INTO bandit_assignments " +
       "(timestamp, experiment, variation_value, subject," +
       " action, action_probability, model_version," +
@@ -99,32 +98,32 @@ Below is an example bandit assignment logger for the Java SDK, defined when buil
       " parse_json(?), parse_json(?)";
 
     try (PreparedStatement statement = snowflakeConnection.prepareStatement(sql)) {
-      statement.setTimestamp(1, new Timestamp(banditLogData.timestamp.getTime()));
-      statement.setString(2, banditLogData.experiment);
-      statement.setString(3, banditLogData.banditKey);
-      statement.setString(4, banditLogData.subject);
-      statement.setString(5, banditLogData.action);
-      statement.setDouble(6, banditLogData.actionProbability);
-      statement.setString(7, banditLogData.modelVersion);
-      if (banditLogData.subjectNumericAttributes == null) {
+      statement.setTimestamp(1, new Timestamp(logData.timestamp.getTime()));
+      statement.setString(2, logData.experiment);
+      statement.setString(3, logData.banditKey);
+      statement.setString(4, logData.subject);
+      statement.setString(5, logData.action);
+      statement.setDouble(6, logData.actionProbability);
+      statement.setString(7, logData.modelVersion);
+      if (logData.subjectNumericAttributes == null) {
         statement.setNull(8, Types.NULL);
       } else {
-        statement.setString(8, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.subjectNumericAttributes));
+        statement.setString(8, EppoAttributes.serializeNonNullAttributesToJSONString(logData.subjectNumericAttributes));
       }
-      if (banditLogData.subjectCategoricalAttributes == null) {
+      if (logData.subjectCategoricalAttributes == null) {
         statement.setNull(9, Types.NULL);
       } else {
-        statement.setString(9, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.subjectCategoricalAttributes));
+        statement.setString(9, EppoAttributes.serializeNonNullAttributesToJSONString(logData.subjectCategoricalAttributes));
       }
-      if (banditLogData.actionNumericAttributes == null) {
+      if (logData.actionNumericAttributes == null) {
         statement.setNull(10, Types.NULL);
       } else {
-        statement.setString(10, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.actionNumericAttributes));
+        statement.setString(10, EppoAttributes.serializeNonNullAttributesToJSONString(logData.actionNumericAttributes));
       }
-      if (banditLogData.actionNumericAttributes == null) {
+      if (logData.actionNumericAttributes == null) {
         statement.setNull(11, Types.NULL);
       } else {
-        statement.setString(11, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.actionCategoricalAttributes));
+        statement.setString(11, EppoAttributes.serializeNonNullAttributesToJSONString(logData.actionCategoricalAttributes));
       }
 
       statement.executeUpdate();

--- a/docs/sdks/server-sdks/java.md
+++ b/docs/sdks/server-sdks/java.md
@@ -69,118 +69,6 @@ The SDK will invoke the `logAssignment` function with an `event` object that con
 More details about logging and examples (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/sdks/event-logging/) page.
 :::
 
-### Define a bandit assignment logger (contextual multi-armed bandit assignment only)
-
-If you are using the Eppo SDK for assignments from a contextual multi-armed bandit, pass in a callback bandit logging 
-function on SDK initialization. The SDK invokes the callback to capture bandit assignment data whenever a bandit chooses
-an action and assigns it.
-
-The SDK will invoke the `logBanditAction` function with an `logData` object that contains the following fields:
-
-| Field                                                | Description                                                                                                     | Example                             |
-|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------|
-| `timestamp` (Date)                                   | The time when the subject was assigned to the variation                                                         | 2024-03-22T14:26:55.000Z            |
-| `experiment` (String)                                | An Eppo experiment key                                                                                          | "bandit-test-allocation-4"          |
-| `key` (String)                                       | The key (unique identifier) of the bandit                                                                       | "ad-bandit-1"                       |
-| `subject` (String)                                   | An identifier of the subject or user assigned to the experiment variation                                       | UUID                                |
-| `subjectNumericAttributes` (Map<String, Double>)     | Metadata about numeric attributes of the subject. Map of the name of attributes their numeric values            | `Map.of("accountAgeDays", 43.0)`    |
-| `subjectCategoricalAttributes` (Map<String, String>) | Metadata about non-numeric attributes of the subject. Map of the name of attributes their string values         | `Map.of("loyaltyTier", "gold")`     |
-| `action` (String)                                    | The action assigned by the bandit                                                                               | "promo-20%-off"                     |
-| `actionNumericAttributes` (Map<String, Double>)      | Metadata about numeric attributes of the assigned action. Map of the name of attributes their numeric values    | `Map.of("discountPercent", 20.0)`   |
-| `actionCategoricalAttributes` (Map<String, String>)  | Metadata about non-numeric attributes of the assigned action. Map of the name of attributes their string values | `Map.of("promoTextColor", "white")` |
-| `actionProbability` (Double)                         | The weight between 0 and 1 the bandit valued the assigned action                                                | 0.25                                |
-| `modelVerison` (String)                              | Unique identifier for the version (iteration) of the bandit parameters used to determine the action probability | "falcon v123"                       |
-
-The code below illustrates an example implementation of a bandit logging callback that writes to Snowflake. 
-
-```java
-import com.eppo.sdk.dto.IBanditLogger;
-import com.eppo.sdk.dto.BanditLogData;
-
-public class BanditLoggerImpl implements IBanditLogger {
-  public void logBanditAction(BanditLogData logData) {
-    String sql = "INSERT INTO bandit_assignments " +
-      "(timestamp, experiment, variation_value, subject," +
-      " action, action_probability, model_version," +
-      " subject_numeric_attributes, subject_categorical_attributes," +
-      " action_numeric_attributes, action_categorical_attributes) " +
-      "SELECT ?, ?, ?, ?," +
-      " ?, ?, ?," +
-      " parse_json(?), parse_json(?)," +
-      " parse_json(?), parse_json(?)";
-
-    try (PreparedStatement statement = snowflakeConnection.prepareStatement(sql)) {
-      statement.setTimestamp(1, new Timestamp(banditLogData.timestamp.getTime()));
-      statement.setString(2, banditLogData.experiment);
-      statement.setString(3, banditLogData.banditKey);
-      statement.setString(4, banditLogData.subject);
-      statement.setString(5, banditLogData.action);
-      statement.setDouble(6, banditLogData.actionProbability);
-      statement.setString(7, banditLogData.modelVersion);
-      if (banditLogData.subjectNumericAttributes == null) {
-        statement.setNull(8, Types.NULL);
-      } else {
-        statement.setString(8, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.subjectNumericAttributes));
-      }
-      if (banditLogData.subjectCategoricalAttributes == null) {
-        statement.setNull(9, Types.NULL);
-      } else {
-        statement.setString(9, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.subjectCategoricalAttributes));
-      }
-      if (banditLogData.actionNumericAttributes == null) {
-        statement.setNull(10, Types.NULL);
-      } else {
-        statement.setString(10, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.actionNumericAttributes));
-      }
-      if (banditLogData.actionNumericAttributes == null) {
-        statement.setNull(11, Types.NULL);
-      } else {
-        statement.setString(11, EppoAttributes.serializeNonNullAttributesToJSONString(banditLogData.actionCategoricalAttributes));
-      }
-
-      statement.executeUpdate();
-    } catch (SQLException e) {
-      throw new RuntimeException("Unable to log bandit assignment "+e.getMessage(), e);
-    }
-  }
-}
-```
-
-Note that `experiment`, `actionProbability` and `modelVersion` are not used for bandit training and do not need to be
-saved to the bandit assignments table. However, they can be useful for transparency around the bandit, so we recommend 
-saving them along with the other information.
-
-### Logging non-bandit actions (contextual multi-armed bandit assignment only)
-
-If the control variation (i.e., not the bandit) was assigned, but the control variation still resulted in an action being
-assigned via some other mechanism, the bandit can still learn from this non-bandit assignment.
-
-To record this event, you can use the `logNonBanditAction()` method.
-
-The code below illustrates an example use of this.
-
-```java
-
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
-
-boolean doControlAction = banditAssignment.isEmpty() || banditAssignment.get().equals("control");
-
-if (doControlAction) {
-  String controlAction = "promo 10% off";
-  EppoAttributes controlActionAttributes = new EppoAttributes(Map.of(
-    "percentOff", EppoValue.of("20"), 
-    "textColor", EppoValue.of("white")
-  );
-
-  handlePromoAction(controlAction);
-  // Log we are taking this action--even though the bandit didn't assign it--to help the bandit learn
-  logNonBanditAction(subjectKey, flagKey, subjectAttributes, controlAction, controlActionAttributes);
-} else {
-  handlePromoAction(banditAssignment.get());
-  // Bandit will have automatically logged the assignment
-}
-```
-
 ## 3. Assign variations
 
 Assigning users to flags or experiments with a single `getStringAssignment` function:
@@ -208,43 +96,6 @@ getJSONStringAssignment(...)
 getParsedJSONAssignment(...)
 ```
 
-### Contextual multi-armed bandit assignments
-
-If the flag or experiment has a variation whose value is decided by a contextual multi-armed bandit, you can provide the
-bandit the set of actions it should consider as a fourth optional argument to `getStringAssignment()`:
-- `actions` - An optional set of action names (if no action attributes) or Map of action names to their attributes 
-
-```java
-// Flag that has a bandit variation
-String banditTestFlagKey = "bandit-test";
-
-// Subject information--same as for retrieving simple flag or experiment assignments
-String subjectKey = username;
-EppoAttributes subjectAttributes = userAttributes;
-
-// Action set for bandits
-Map<String, EppoAttributes> actionsWithAttributes = Map.of(
-  "dog", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(4),
-    "size": "large"
-  )),
-  "cat", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(4),
-    "size": "medium"
-  )),
-  "bird", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(2),
-    "size": "medium"
-  )),
-  "goldfish", new EppoAttributes(Map.of(
-    "legs": EppoValue.of(0),
-    "size": "small" 
-  ))   
-);
-
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
-```
-
 ### Handling the empty assignment
 
 We recommend always handling the empty assignment case in your code. Here are some examples illustrating when the SDK returns `Optional.empty()`:
@@ -262,3 +113,171 @@ We recommend always handling the empty assignment case in your code. Here are so
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
 :::
+
+## 4. Usage with Contextual Multi-Armed Bandits
+
+If using the SDK to train and request actions from a contextual multi-armed bandit, you will need to:
+1. Define a bandit assignment logger
+2. Pass bandit actions to request a bandit assignment
+3. (Optional) Log non-bandit actions
+
+### Define a bandit assignment logger
+
+When using the Eppo SDK for assignments from a contextual multi-armed bandit, you will need to pass in a callback 
+bandit logging function on SDK initialization. The SDK invokes the callback to capture bandit assignment data whenever a 
+bandit chooses an action and assigns it.
+
+The SDK will invoke the `logBanditAction` function with an `logData` object that contains the following fields:
+
+| Field                                                | Description                                                                                                     | Example                             |
+|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| `timestamp` (Date)                                   | The time when the subject was assigned to the variation                                                         | 2024-03-22T14:26:55.000Z            |
+| `experiment` (String)                                | An Eppo experiment key                                                                                          | "bandit-test-allocation-4"          |
+| `key` (String)                                       | The key (unique identifier) of the bandit                                                                       | "ad-bandit-1"                       |
+| `subject` (String)                                   | An identifier of the subject or user assigned to the experiment variation                                       | "ed6f85019080"                      |
+| `subjectNumericAttributes` (Map<String, Double>)     | Metadata about numeric attributes of the subject. Map of the name of attributes their numeric values            | `Map.of("accountAgeDays", 43.0)`    |
+| `subjectCategoricalAttributes` (Map<String, String>) | Metadata about non-numeric attributes of the subject. Map of the name of attributes their string values         | `Map.of("loyaltyTier", "gold")`     |
+| `action` (String)                                    | The action assigned by the bandit                                                                               | "promo-20%-off"                     |
+| `actionNumericAttributes` (Map<String, Double>)      | Metadata about numeric attributes of the assigned action. Map of the name of attributes their numeric values    | `Map.of("discountPercent", 20.0)`   |
+| `actionCategoricalAttributes` (Map<String, String>)  | Metadata about non-numeric attributes of the assigned action. Map of the name of attributes their string values | `Map.of("promoTextColor", "white")` |
+| `actionProbability` (Double)                         | The weight between 0 and 1 the bandit valued the assigned action                                                | 0.25                                |
+| `modelVerison` (String)                              | Unique identifier for the version (iteration) of the bandit parameters used to determine the action probability | "falcon v123"                       |
+
+The code below illustrates an example implementation of a bandit logging callback that writes to Snowflake.
+
+```java
+import com.eppo.sdk.dto.IBanditLogger;
+import com.eppo.sdk.dto.BanditLogData;
+import Java.sql.Connection;
+
+public class BanditLoggerImpl implements IBanditLogger {
+
+  private final Connection snowflakeConnection;
+
+  public BanditLoggerImpl(Connection snowflakeConnection) {
+    this.snowflakeConnection = snowflakeConnection;
+  }
+  public void logBanditAction(BanditLogData logData) {
+    String sql = "INSERT INTO bandit_assignments " +
+      "(timestamp, experiment, variation_value, subject," +
+      " action, action_probability, model_version," +
+      " subject_numeric_attributes, subject_categorical_attributes," +
+      " action_numeric_attributes, action_categorical_attributes) " +
+      "SELECT ?, ?, ?, ?," +
+      " ?, ?, ?," +
+      " parse_json(?), parse_json(?)," +
+      " parse_json(?), parse_json(?)";
+
+    try (PreparedStatement statement = snowflakeConnection.prepareStatement(sql)) {
+      statement.setTimestamp(1, new Timestamp(logData.timestamp.getTime()));
+      statement.setString(2, logData.experiment);
+      statement.setString(3, logData.banditKey);
+      statement.setString(4, logData.subject);
+      statement.setString(5, logData.action);
+      statement.setDouble(6, logData.actionProbability);
+      statement.setString(7, logData.modelVersion);
+      if (logData.subjectNumericAttributes == null) {
+        statement.setNull(8, Types.NULL);
+      } else {
+        statement.setString(8, EppoAttributes.serializeNonNullAttributesToJSONString(logData.subjectNumericAttributes));
+      }
+      if (logData.subjectCategoricalAttributes == null) {
+        statement.setNull(9, Types.NULL);
+      } else {
+        statement.setString(9, EppoAttributes.serializeNonNullAttributesToJSONString(logData.subjectCategoricalAttributes));
+      }
+      if (logData.actionNumericAttributes == null) {
+        statement.setNull(10, Types.NULL);
+      } else {
+        statement.setString(10, EppoAttributes.serializeNonNullAttributesToJSONString(logData.actionNumericAttributes));
+      }
+      if (logData.actionNumericAttributes == null) {
+        statement.setNull(11, Types.NULL);
+      } else {
+        statement.setString(11, EppoAttributes.serializeNonNullAttributesToJSONString(logData.actionCategoricalAttributes));
+      }
+
+      statement.executeUpdate();
+    } catch (SQLException e) {
+      throw new RuntimeException("Unable to log bandit assignment "+e.getMessage(), e);
+    }
+  }
+}
+```
+
+Note that `experiment`, `actionProbability` and `modelVersion` are not used for bandit training and do not need to be
+saved to the bandit assignments table. However, they can be useful for transparency around the bandit, so we recommend
+saving them along with the other information.
+
+### Pass bandit actions to request a bandit assignment
+
+If the flag or experiment has a variation whose value is decided by a contextual multi-armed bandit, you can provide the
+bandit the set of actions it should consider as a fourth optional argument to `getStringAssignment()`:
+- `actions` - An optional `Set<String>` of action names (if no action attributes) or `Map<String, EppoAttributes>` of 
+action names to their attributes
+
+If the user is assigned the bandit variation, the bandit will then score and weight each action using the attributes of 
+the action and subject, and then randomly assign an action. Note that the action assigned may change as the bandit's 
+model evolves.
+
+```java
+// Flag that has a bandit variation
+String banditTestFlagKey = "bandit-test";
+
+// Subject information--same as for retrieving simple flag or experiment assignments
+String subjectKey = username;
+EppoAttributes subjectAttributes = userAttributes;
+
+// Action set for bandits
+Map<String, EppoAttributes> actionsWithAttributes = Map.of(
+  "dog", new EppoAttributes(Map.of(
+  "legs", EppoValue.valueOf(4),
+  "size", EppoValue.valueOf("large")
+)),
+  "cat", new EppoAttributes(Map.of(
+  "legs", EppoValue.valueOf(4),
+  "size", EppoValue.valueOf("medium")
+)),
+  "bird", new EppoAttributes(Map.of(
+  "legs", EppoValue.valueOf(2),
+  "size", EppoValue.valueOf("medium")
+)),
+  "goldfish", new EppoAttributes(Map.of(
+  "legs", EppoValue.valueOf(0),
+  "size", EppoValue.valueOf("small")
+))
+
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
+```
+
+### Logging non-bandit actions (contextual multi-armed bandit assignment only)
+
+If the control variation (i.e., not the bandit) was assigned, but the control variation still resulted in an action being
+assigned via some other mechanism, the bandit can still learn from this non-bandit assignment.
+
+To record this event, you can use the `logNonBanditAction()` method.
+
+The code below illustrates an example use of this.
+
+```java
+
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
+
+boolean doControlAction = banditAssignment.isEmpty() || banditAssignment.get().equals("control");
+
+if (doControlAction) {
+  String controlAction = "promo 10% off";
+  EppoAttributes controlActionAttributes = new EppoAttributes(Map.of(
+    "percentOff", EppoValue.valueOf("20"),
+    "textColor", EppoValue.valueOf("white")
+  ));
+
+  handlePromoAction(controlAction);
+  
+  // Log we are taking this action--even though the bandit didn't assign it--to help the bandit learn
+  eppoClient.logNonBanditAction(subjectKey, flagKey, subjectAttributes, controlAction, controlActionAttributes);
+} else {
+  handlePromoAction(banditAssignment.get());
+  // Bandit will have automatically logged the assignment
+}
+```


### PR DESCRIPTION
🎟️  **Ticket:** [FF-1777 - Update documentation for bandits](https://linear.app/eppo/issue/FF-1777/update-documentation-for-bandits)

Here we add in the documentation about interacting with bandits to the Java Server SDK.

I also added a higher-level bandits section in the SDK Features section. Note it uses Java examples (many from the Java Server SDK documentation), as this is the only SDK we have right now.