### PR TITLE
Updated ratio metric docs to explain motivation and provide more deta…

### DIFF
--- a/docs/data-management/metrics/ratio-metric.md
+++ b/docs/data-management/metrics/ratio-metric.md
@@ -3,14 +3,53 @@ sidebar_position: 2
 ---
 
 # Ratio metrics
+## Overview
+Ratio metrics allow you to calculate the ratio of two [simple metrics](/data-management/metrics/simple-metric). The most common use case for this is when the randomization entity is different from the analysis entity. 
+For example, consider the metric _average  order value_. Typically, experiments are not randomized at the _order_ level because a user can have multiple orders. 
+Consequently, randomizing orders could lead to users experiencing multiple variants. When the experiment is randomized at the user level, it is not statistically valid to consider each
+_order_ an independent observation because orders from the same user are related. Treating the orders as statistically independent observations in experiments with user-based
+randomization typically leads to overconfident results (underestimating the variance). A proper estimation of the variance must recognize the fact that the observations (orders) are clustered
+at the user level. Although there are several valid approaches for estimating this variance, including [clustered standard errors](https://en.wikipedia.org/wiki/Clustered_standard_errors),
+Eppo uses the approach described in [Deng et al.](https://alexdeng.github.io/public/files/kdd2018-dm.pdf) and recommended in 
+Chapter 18 of _Trustworthy Online Controlled Experiments: A Practical Guide to A/B Testing_ by Ron Kohavi.
 
-Ratio metrics allow you to calculate ratio of two [simple metrics](/data-management/metrics/simple-metric), providing deeper insights into the relative performance of variations. This enables a more nuanced analysis of experimental results, allowing businesses to understand the impact of changes in a more comprehensive manner.
 
-For example, consider an _average order value_ metric, which is created by dividing revenue (sum of prices) by number of orders (_sum_ of items purchased or _count_ of prices).
+The approach is to redefine the metric of interest as a ratio of two simple metrics. For example, take _average order value_, which is defined by 
+dividing revenue (sum of prices) by the number of orders (sum of items purchased or count of prices).
+
 
 $$
 \text{Average order value} = \frac{\text{Revenue}}{\text{Number of orders}}
 $$
+
+We can multiply both the numerator and the denominator by the number of _users_ in the experiment:
+
+$$
+\text{Average order value} = \frac{\text{(Revenue)(Number of users)}}{\text{(Number of orders)(Number of users)}}
+$$
+
+which we can rearrange as follows:
+$$
+\text{Average order value} = \bigg(\frac{\text{Revenue}} {\text{Number of users}}\bigg) \bigg(\frac{\text{Number of users}} {\text{Number of orders}}\bigg)
+$$
+
+which can be expressed as the ratio of two simple metrics:
+$$
+\text{Average order value} = \frac{\text{Revenue per user}}{\text{Number of orders per user}}
+$$
+
+Both the numerator and the denominator are simple metrics whose analysis entity matches the randomization entity (a user). In general, the steps to define a ratio metric are
+as follows:
+1. Define the metric you wish to calculate and identify its analysis entity (e.g., an order in _average order value_).
+2. Divide both the numerator and the denominator by the _randomization_ entity (often a user).
+3. Identify the numerator metric and the denominator metric. The numerator metric will typically be a fact quantity per randomization entity (e.g., revenue per user). The denominator metric will typically be a count of the analysis entity per randomization entity (e.g., number of orders per user).
+4. Make sure that both the numerator metric and the denominator metric are already defined as [simple metrics](/data-management/metrics/simple-metric) in Eppo.
+5. Create the desired ratio metric by following the steps in the next section.
+
+### Common examples
+- _Average order value_ as discussed in the example above.
+- _Average revenue per DAU_. In this case, the randomization entity is typically a user, while the analysis entity is technically an _active day_. The corresponding numerator and denominator metrics are _revenue per user_ (sum of order values) and _number of active days per user_ (count distinct active days).
+
 
 :::note
 Ratio metrics are computed by first computing averaged values for the numerator and the denominator, and then dividing them to compute the ratio, rather than computing the ratio on a user level and then taking the average.

--- a/docs/data-management/metrics/ratio-metric.md
+++ b/docs/data-management/metrics/ratio-metric.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # Ratio metrics
 ## Overview
 Ratio metrics allow you to calculate the ratio of two [simple metrics](/data-management/metrics/simple-metric). The most common use case for this is when the randomization entity is different from the analysis entity. 
-For example, consider the metric _average  order value_. Typically, experiments are not randomized at the _order_ level because a user can have multiple orders. 
+For example, consider the metric _average order value_. Typically, experiments are not randomized at the _order_ level because a user can have multiple orders. 
 Consequently, randomizing orders could lead to users experiencing multiple variants. When the experiment is randomized at the user level, it is not statistically valid to consider each
 _order_ an independent observation because orders from the same user are related. Treating the orders as statistically independent observations in experiments with user-based
 randomization typically leads to overconfident results (underestimating the variance). A proper estimation of the variance must recognize the fact that the observations (orders) are clustered

--- a/docs/data-management/metrics/ratio-metric.md
+++ b/docs/data-management/metrics/ratio-metric.md
@@ -39,10 +39,13 @@ $$
 $$
 
 Both the numerator and the denominator are simple metrics whose analysis entity matches the randomization entity (a user). In general, the steps to define a ratio metric are
-as follows:
+as follows. Note that Eppo automatically divides [simple metrics](/data-management/metrics/simple-metric) by the unique count of the randomization entity, so you do not need to explicitly specify this
+step when creating ratio metrics. For example, in the above example, the numerator metric is _revenue per user_, but you only need to specify a `SUM` aggregation for the numerator. The "per user" component is 
+implied based on the randomization entity.
+
 1. Define the metric you wish to calculate and identify its analysis entity (e.g., an order in _average order value_).
-2. Divide both the numerator and the denominator by the _randomization_ entity (often a user).
-3. Identify the numerator metric and the denominator metric. The numerator metric will typically be a fact quantity per randomization entity (e.g., revenue per user). The denominator metric will typically be a count of the analysis entity per randomization entity (e.g., number of orders per user).
+2. Identify the fact and aggregation for the numerator. In most cases, this will be a sum or a count. In our above example, it would be the sum of revenue.
+3. Identify the fact and aggregation for the denominator. In most cases, this will be a count of the analysis entity. In our above example, it would be the count of orders.
 4. Create the desired ratio metric by following the steps in the next section.
 
 ### Common examples

--- a/docs/data-management/metrics/ratio-metric.md
+++ b/docs/data-management/metrics/ratio-metric.md
@@ -4,54 +4,34 @@ sidebar_position: 2
 
 # Ratio metrics
 ## Overview
-Ratio metrics allow you to calculate the ratio of two [simple metrics](/data-management/metrics/simple-metric). The most common use case for this is when the randomization entity is different from the analysis entity. 
-For example, consider the metric _average order value_. Typically, experiments are not randomized at the _order_ level because a user can have multiple orders. 
-Consequently, randomizing orders could lead to users experiencing multiple variants. When the experiment is randomized at the user level, it is not statistically valid to consider each
-_order_ an independent observation because orders from the same user are related. Treating the orders as statistically independent observations in experiments with user-based
-randomization typically leads to overconfident results (underestimating the variance). A proper estimation of the variance must recognize the fact that the observations (orders) are clustered
-at the user level. Although there are several valid approaches for estimating this variance, including [clustered standard errors](https://en.wikipedia.org/wiki/Clustered_standard_errors),
-Eppo uses the approach described in [Deng et al.](https://alexdeng.github.io/public/files/kdd2018-dm.pdf) and recommended in 
-Chapter 18 of _Trustworthy Online Controlled Experiments: A Practical Guide to A/B Testing_ by Ron Kohavi.
+Ratio metrics allow you to calculate the ratio of two fact aggregations. Unlike [Simple metrics](/data-management/metrics/simple-metric), which normalize a fact aggregation by the number of unique [entities](https://docs.geteppo.com/data-management/entities) (e.g., users) in the experiment, 
+ratio metrics normalize a fact aggregation by another user-defined fact aggregation. To make this concrete, let's consider a few examples.
 
-
-The approach is to redefine the metric of interest as a ratio of two simple metrics. For example, take _average order value_, which is defined by 
-dividing revenue (sum of prices) by the number of orders (sum of items purchased or count of prices).
-
+### Example 1: Average Order Value (AOV)
+Average order value is defined as the total amount of revenue divided by the total number of orders:
 
 $$
 \text{Average order value} = \frac{\text{Revenue}}{\text{Number of orders}}
 $$
 
-We can multiply both the numerator and the denominator by the number of _users_ in the experiment:
+This metric is often calculated in experiments that are randomized at the user level. However, it is clear from this metric's definition that we need to normalize by the
+number of **orders** rather than the number of **users** (which simple metrics would do automatically). To capture this custom aggregation logic in the denominator, we define it as a ratio metric.
+The numerator aggregation is the sum of revenue, and the denominator aggregation is the count of orders.
+
+### Example 2: Average revenue per paying user (ARPPU)
+_Average revenue per paying user_ is defined as the total amount of revenue divided by the total number of payers in the
+experiment.
 
 $$
-\text{Average order value} = \frac{\text{(Revenue)(Number of users)}}{\text{(Number of orders)(Number of users)}}
+\text{Average revenue per paying user} = \frac{\text{Revenue}}{\text{Number of payers}}
 $$
 
-which we can rearrange as follows:
-$$
-\text{Average order value} = \bigg(\frac{\text{Revenue}} {\text{Number of users}}\bigg) \bigg(\frac{\text{Number of users}} {\text{Number of orders}}\bigg)
-$$
-
-which can be expressed as the ratio of two simple metrics:
-$$
-\text{Average order value} = \frac{\text{Revenue per user}}{\text{Number of orders per user}}
-$$
-
-Both the numerator and the denominator are simple metrics whose analysis entity matches the randomization entity (a user). In general, the steps to define a ratio metric are
-as follows. Note that Eppo automatically divides [simple metrics](/data-management/metrics/simple-metric) by the unique count of the randomization entity, so you do not need to explicitly specify this
-step when creating ratio metrics. For example, in the above example, the numerator metric is _revenue per user_, but you only need to specify a `SUM` aggregation for the numerator. The "per user" component is 
-implied based on the randomization entity.
-
-1. Define the metric you wish to calculate and identify its analysis entity (e.g., an order in _average order value_).
-2. Identify the fact and aggregation for the numerator. In most cases, this will be a sum or a count. In our above example, it would be the sum of revenue.
-3. Identify the fact and aggregation for the denominator. In most cases, this will be a count of the analysis entity. In our above example, it would be the count of orders.
-4. Create the desired ratio metric by following the steps in the next section.
-
-### Common examples
-- _Average order value_ as discussed in the example above.
-- _Average revenue per DAU_. In this case, the randomization entity is typically a user, while the analysis entity is technically an _active day_. The corresponding numerator and denominator metrics are _revenue per user_ (sum of order values) and _number of active days per user_ (count distinct active days).
-
+Although this metric is a ratio metric, it is closely related to a simple metric, which makes this example especially useful for illustrating the 
+difference between the two metric types. If we wanted to define the metric _average revenue per assigned user_, that would be
+specified as a simple metric because it is "per assigned user" and, therefore, is normalized by the entity count (a defining characteristic of simple metrics).
+However, ARPPU is "per _paying_ user." The fact that we are normalizing by only a count of a _subset_ of users rather than a count of _all_ assigned users indicates
+that ARPPU must be specified as a ratio metric. In this case, the numerator aggregation is a sum of revenue, and the denominator aggregation is a
+count of unique payers.
 
 :::note
 Ratio metrics are computed by first computing averaged values for the numerator and the denominator, and then dividing them to compute the ratio, rather than computing the ratio on a user level and then taking the average.
@@ -64,8 +44,12 @@ We use the [Delta method](/statistics/confidence-intervals/statistical-nitty-gri
 :::
 
 ## Creating a ratio metric
+In general, the steps to define a ratio metric are as follows:
+1. Define the metric you wish to calculate and identify its analysis unit (e.g., an _order_ in _average order value_ or _X_ in a metric that has "_per X_" in its name)
+2. Identify the fact and aggregation for the numerator. In most cases, this will be a sum or a count (e.g., a sum of revenue).
+3. Identify the fact and aggregation for the denominator. In most cases, this will be a count of the analysis entity from step 1 (e.g., a count of purchases/orders). Verify that the aggregation is **not** a unique count of assigned entities because that means your metric is a simple metric rather than a ratio metric.
 
-Creating a ratio metric follows the same approach as creating a simple metric.
-Of course, the difference is that for a ratio metric, you have to select both a fact and aggregation for numerator and denominator.
+Once you have identified your desired ratio metric and its constituent fact aggregations, you can define it in Eppo
+using the same process as creating a simple metric.  Of course, the difference is that for a ratio metric, you have to select both a fact and an aggregation for the numerator and denominator.
 
 ![Creating a ratio metric](/img/data-management/metrics/create-ratio-metric.png)

--- a/docs/data-management/metrics/ratio-metric.md
+++ b/docs/data-management/metrics/ratio-metric.md
@@ -43,8 +43,7 @@ as follows:
 1. Define the metric you wish to calculate and identify its analysis entity (e.g., an order in _average order value_).
 2. Divide both the numerator and the denominator by the _randomization_ entity (often a user).
 3. Identify the numerator metric and the denominator metric. The numerator metric will typically be a fact quantity per randomization entity (e.g., revenue per user). The denominator metric will typically be a count of the analysis entity per randomization entity (e.g., number of orders per user).
-4. Make sure that both the numerator metric and the denominator metric are already defined as [simple metrics](/data-management/metrics/simple-metric) in Eppo.
-5. Create the desired ratio metric by following the steps in the next section.
+4. Create the desired ratio metric by following the steps in the next section.
 
 ### Common examples
 - _Average order value_ as discussed in the example above.


### PR DESCRIPTION
…iled use-cases

Our current ratio metrics documents are a bit lacking in detail. IMO, they don't equip users with sufficient knowledge to understand whether a given metric needs to be a simple metric vs. a ratio metric.

There is even more confusion because _not all ratios are ratio metrics_, and simple metrics are ratios (they normalize by the count of assigned entities).

After several discussions, we decided that the best way to explain this topic is to introduce examples that clearly articulate the defining characteristics of ratio metrics. The ARPU/ARPPU one is especially interesting because average revenue per assigned user is a simple metric, but average revenue per paying user is a ratio metric. This distinction is especially effective in communicating the difference.



