### PR TITLE
Update non-JS, non-Python SDKs to v3

### DIFF
--- a/docs/feature-flagging/feature-gates.md
+++ b/docs/feature-flagging/feature-gates.md
@@ -32,7 +32,7 @@ user_attributes = {
     device: user.device
 }
 
-if (eppoClient.getStringAssignment(user.id, 'new-checkout-page', user_attributes) == 'on'):
+if (eppoClient.getStringAssignment(user.id, 'new-checkout-page', 'off', user_attributes) == 'on'):
     # Show new checkout page.
 else:
     # Show old checkout page.

--- a/docs/feature-flagging/index.md
+++ b/docs/feature-flagging/index.md
@@ -28,7 +28,7 @@ The presence of a feature flag unlocks multiple paths:
 ```python
 # After, show different prices to different users based on a flag.
 
-group = get_string_assignment(user_id, 'pricing_gate')
+group = get_string_assignment(user_id, 'pricing_gate', 'do_not_round_down')
 
 if (group == "round_down_to_cents"):
     price_of_shoes = 9.99

--- a/docs/feature-flagging/kill-switches.md
+++ b/docs/feature-flagging/kill-switches.md
@@ -26,7 +26,7 @@ Here's how you would use the switch in your code:
 ```python
 # The argument user_id is required but doesn't affect assignment in this case.
 
-if (eppoClient.getStringAssignment(user_id, 'twilio-killswitch') == 'on'):
+if (eppoClient.getStringAssignment(user_id, 'twilio-killswitch', 'off') == 'on'):
     # Code to gracefully handle a Twilio outage.
 else:
     # Normal Twilio code.

--- a/docs/feature-flagging/targeting.md
+++ b/docs/feature-flagging/targeting.md
@@ -42,7 +42,7 @@ client = eppo_client.get_instance()
 variation = client.get_string_assignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   { "device": "iOS", "appVersion": "28.5.0" }
 )
 ```

--- a/docs/feature-flagging/targeting.md
+++ b/docs/feature-flagging/targeting.md
@@ -40,8 +40,9 @@ import eppo_client
 
 client = eppo_client.get_instance()
 variation = client.get_string_assignment(
-  "<SUBJECT-KEY>", 
-  "<EXPERIMENT-KEY>", 
+  "<SUBJECT-KEY>",
+  "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   { "device": "iOS", "appVersion": "28.5.0" }
 )
 ```

--- a/docs/guides/integrating-with-contentful.md
+++ b/docs/guides/integrating-with-contentful.md
@@ -67,15 +67,15 @@ await init({
     apiKey: <EPPO SDK KEY>
 });
 
-let userid = “user id”
+let userId = “user id”
 let flagKey = <EPPO FLAG KEY>
 
 const eppoClient = EppoSdk.getInstance();
 
 const homepage_entry_id = eppoClient.getStringAssignment(
-    userid, // unique identifier for the user
+    userId, // unique identifier for the user
     flagKey, // flag key from Eppo UI
-    defaultVariation,
+    defaultValue,
 )
 console.log(flag_key, homepage_entry_id)
 

--- a/docs/guides/integrating-with-contentful.md
+++ b/docs/guides/integrating-with-contentful.md
@@ -68,13 +68,14 @@ await init({
 });
 
 let userid = “user id”
-let flag_key = <EPPO FLAG KEY>
+let flagKey = <EPPO FLAG KEY>
 
 const eppoClient = EppoSdk.getInstance();
 
 const homepage_entry_id = eppoClient.getStringAssignment(
     userid, // unique identifier for the user
-    flag_key, // flag key from Eppo UI
+    flagKey, // flag key from Eppo UI
+    defaultVariation,
 )
 console.log(flag_key, homepage_entry_id)
 

--- a/docs/guides/mutually-exclusive-experiments.md
+++ b/docs/guides/mutually-exclusive-experiments.md
@@ -60,7 +60,8 @@ const eppoClient = EppoSdk.getInstance();
 // randomize assignment for which exclusion group they will be in
 const exclusion_group = eppoClient.getStringAssignment(
   userId,
-  "mutual_exclusion_group"
+  "mutual_exclusion_group",
+  "<default_variation>"
 )
 
 // user profile
@@ -73,12 +74,14 @@ let user = {
 const copy_variation = eppoClient.getStringAssignment(
 												 user.userId,
 												 "copy_test",
+												 "<default_variation>",
 				                 {"exclusion_group": exclusion_group}
 											 )
 // randomize assignment on what variation the user will receive for the Layout Test
 const layout_variation = eppoClient.getStringAssignment(
 												 user.userId,
 												 "layout_test",
+												 "<default_variation>",
 				                 {"exclusion_group": exclusion_group}
 											 )
 ```

--- a/docs/guides/mutually-exclusive-experiments.md
+++ b/docs/guides/mutually-exclusive-experiments.md
@@ -61,7 +61,7 @@ const eppoClient = EppoSdk.getInstance();
 const exclusion_group = eppoClient.getStringAssignment(
   userId,
   "mutual_exclusion_group",
-  "<default_variation>"
+  "<default_value>"
 )
 
 // user profile
@@ -74,14 +74,14 @@ let user = {
 const copy_variation = eppoClient.getStringAssignment(
 												 user.userId,
 												 "copy_test",
-												 "<default_variation>",
+												 "<default_value>",
 				                 {"exclusion_group": exclusion_group}
 											 )
 // randomize assignment on what variation the user will receive for the Layout Test
 const layout_variation = eppoClient.getStringAssignment(
 												 user.userId,
 												 "layout_test",
-												 "<default_variation>",
+												 "<default_value>",
 				                 {"exclusion_group": exclusion_group}
 											 )
 ```

--- a/docs/quick-starts/bandit-quickstart.md
+++ b/docs/quick-starts/bandit-quickstart.md
@@ -164,7 +164,7 @@ If the actions don't have attributes for the context, you can simply provide a s
 ```java
 Set<String> actions = Set.of("dog", "cat", "bird", "goldfish");
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actions);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actions);
 ```
 
 Note that the `getStringAssignment` method in Eppo is deterministic, meaning that it will return the same variant for a given subject (e.g., user) for two consecutive calls. (The variant may change over time as the bandit learns how which variants perform best for different attributes.)

--- a/docs/quick-starts/bandit-quickstart.md
+++ b/docs/quick-starts/bandit-quickstart.md
@@ -164,7 +164,7 @@ If the actions don't have attributes for the context, you can simply provide a s
 ```java
 Set<String> actions = Set.of("dog", "cat", "bird", "goldfish");
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actions);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultValue, subjectAttributes, actions);
 ```
 
 Note that the `getStringAssignment` method in Eppo is deterministic, meaning that it will return the same variant for a given subject (e.g., user) for two consecutive calls. (The variant may change over time as the bandit learns how which variants perform best for different attributes.)

--- a/docs/quick-starts/feature-flag-quickstart.md
+++ b/docs/quick-starts/feature-flag-quickstart.md
@@ -102,9 +102,10 @@ import * as EppoSdk from "@eppo/js-client-sdk";
 const eppoClient = EppoSdk.getInstance();
 
 const variation = eppoClient.getBoolAssignment(
-  user.id,
-  "new-checkout-page",
-  // if using Eppo to target users, pass in user properties as optional third argument
+  user.id, // subject key
+  "use-new-checkout-page", // flag key
+  false, // default value
+  // if using Eppo to target users, pass in user properties as optional fourth argument
   // userProperties
 );
 

--- a/docs/sdks/client-sdks/android.md
+++ b/docs/sdks/client-sdks/android.md
@@ -84,14 +84,14 @@ For example, for a String-valued flag, use `getStringAssignment`:
 import cloud.eppo.android.EppoClient;
 
 EppoClient eppoClient = EppoClient.getInstance(); // requires the SDK to already be initialized
-String variation = eppoClient.getStringAssignment("<SUBJECT-KEY>", "<FLAG-KEY>", "<DEFAULT-VARIATION>");
+String variation = eppoClient.getStringAssignment("<SUBJECT-KEY>", "<FLAG-KEY>", "<DEFAULT-VALUE>");
 ```
 
 The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 The following typed functions are available:

--- a/docs/sdks/client-sdks/android.md
+++ b/docs/sdks/client-sdks/android.md
@@ -77,43 +77,32 @@ More details about logging and examples (with Segment, Rudderstack, mParticle, a
 
 ## 3. Assign variations
 
-Assigning users to flags or experiments with a single `getStringAssignment` function:
+Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `getStringAssignment`:
 
 ```java
 import cloud.eppo.android.EppoClient;
 
 EppoClient eppoClient = EppoClient.getInstance(); // requires the SDK to already be initialized
-String variation = eppoClient.getStringAssignment("<SUBJECT-KEY>", "<FLAG-KEY>");
+String variation = eppoClient.getStringAssignment("<SUBJECT-KEY>", "<FLAG-KEY>", "<DEFAULT-VARIATION>");
 ```
 
-The `getStringAssignment` function takes two required and one optional input to assign a variation:
+The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
-Starting in version `v1.0.0` typed functions are available:
+The following typed functions are available:
 
 ```
-eppoClient.getBooleanAssignment(...)
-eppoClient.getDoubleAssignment(...)
-eppoClient.getJSONStringAssignment(...)
-eppoClient.getParsedJSONAssignment(...)
+getBooleanAssignment(...)
+getDoubleAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
-
-### Handling `null`
-
-We recommend always handling the `null` case in your code. Here are some examples illustrating when the SDK returns `null`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `null` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `null` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `null` if no configurations have been downloaded.
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.

--- a/docs/sdks/client-sdks/ios.md
+++ b/docs/sdks/client-sdks/ios.md
@@ -120,7 +120,7 @@ The `getStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 ### Typed assignments

--- a/docs/sdks/client-sdks/ios.md
+++ b/docs/sdks/client-sdks/ios.md
@@ -71,18 +71,20 @@ More details about logging and examples (with Segment, Rudderstack, mParticle, a
 
 ## 3. Assign Variations
 
-Assigning users to flags or experiments with a single getStringAssignment function:
+Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `getStringAssigment`:
 
 ```swift
 Task {
     do {
         try await eppoClient.load();
         self.assignment = try self.eppoClient.getStringAssignment(
-            "test-user",
-            "ios-test-app-treatment"
+            "test-user", // subject key
+            "ios-test-app-treatment", // flag key
+            "control" // default variation
         );
     } catch {
-        self.assignment = nil;
+        self.assignment = "control";
     }
 }
 ```
@@ -102,46 +104,36 @@ class AssignmentObserver : ObservableObject {
             do {
                 try await eppoClient.load();
                 self.assignment = try self.eppoClient.getStringAssignment(
-                    "test-user", // identifier to randomize (typically a user id)
-                    "ios-test-app-treatment" // the variation to select from
+                    "test-user", // subject key
+                    "ios-test-app-treatment", // flag key
+                    "control" // default variation
                 );
             } catch {
-                self.assignment = nil;
+                self.assignment = "control";
             }
         }
     }
 }
 ```
 
-The `getStringAssignment` function takes two required and one optional input to assign a variation:
+The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 ### Typed assignments
 
-Additional functions are available:
+The following typed functions are available:
 
 ```swift
 getBoolAssignment(...)
 getNumericAssignment(...)
-getJSONStringAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
-
-## 4. Handling `nil`
-
-We recommend always handling the `nil` case in your code. Here are some examples illustrating when the SDK returns `nil`:
-
-1. The Traffic Exposure setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `nil` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `nil` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `nil` if no configurations have been downloaded.
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.

--- a/docs/sdks/client-sdks/javascript.md
+++ b/docs/sdks/client-sdks/javascript.md
@@ -129,7 +129,8 @@ Eppo's SDK uses an internal cache to ensure that duplicate assignment events are
 
 ## 3. Assign variations
 
-Assigning users to flags or experiments with a single `getStringAssignment` function:
+Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `getStringAssignment`:
 
 ```javascript
 import * as EppoSdk from "@eppo/js-client-sdk";
@@ -138,42 +139,31 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional map of subject metadata for targeting.
   }
 );
 ```
 
-The `getStringAssignment` function takes two required and one optional input to assign a variation:
+The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
+- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 ### Typed assignments
 
-Additional functions are available:
+The following typed functions are available:
 
-```
+```javascript
 getBoolAssignment(...)
 getNumericAssignment(...)
-getJSONStringAssignment(...)
-getParsedJSONAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
-
-### Handling `null`
-
-We recommend always handling the `null` case in your code. Here are some examples illustrating when the SDK returns `null`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `null` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `null` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `null` if no configurations have been downloaded.
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
@@ -234,7 +224,7 @@ After the SDK is initialized, you may assign variations from any child component
 function MyComponent(): JSX.Element {
   const assignedVariation = useMemo(() => {
     const eppoClient = getInstance();
-    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>");
+    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", "<DEFAULT-VARIATION>");
   }, []);
 
   return (

--- a/docs/sdks/client-sdks/javascript.md
+++ b/docs/sdks/client-sdks/javascript.md
@@ -139,7 +139,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional map of subject metadata for targeting.
   }
@@ -150,7 +150,7 @@ The `getStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 ### Typed assignments
@@ -224,7 +224,7 @@ After the SDK is initialized, you may assign variations from any child component
 function MyComponent(): JSX.Element {
   const assignedVariation = useMemo(() => {
     const eppoClient = getInstance();
-    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", "<DEFAULT-VARIATION>");
+    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", "<DEFAULT-VALUE>");
   }, []);
 
   return (

--- a/docs/sdks/client-sdks/react-native.md
+++ b/docs/sdks/client-sdks/react-native.md
@@ -103,7 +103,8 @@ Eppo's SDK uses an internal cache to ensure that duplicate assignment events are
 
 ## 3. Assign variations
 
-Assigning users to flags or experiments with a single `getStringAssignment` function:
+Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `getStringAssignment`:
 
 ```javascript
 import * as EppoSdk from "@eppo/react-native-sdk";
@@ -112,42 +113,32 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional map of subject metadata for targeting.
   }
 );
 ```
 
-The `getStringAssignment` function takes two required and one optional input to assign a variation:
+The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
+- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+
 
 ### Typed assignments
 
-Additional functions are available:
+The following typed functions are available:
 
-```
+```javascript
 getBoolAssignment(...)
 getNumericAssignment(...)
-getJSONStringAssignment(...)
-getParsedJSONAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
-
-### Handling `null`
-
-We recommend always handling the `null` case in your code. Here are some examples illustrating when the SDK returns `null`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `null` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `null` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `null` if no configurations have been downloaded.
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
@@ -208,7 +199,7 @@ After the SDK is initialized, you may assign variations from any child component
 function MyComponent(): JSX.Element {
   const assignedVariation = useMemo(() => {
     const eppoClient = getInstance();
-    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>");
+    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", "<DEFAULT-VARIATION>");
   }, []);
 
   return (
@@ -221,4 +212,4 @@ function MyComponent(): JSX.Element {
 
 ### Local Storage
 
-The SDK uses `@react-native-async-storage` to store experiment configurations downloaded from Eppo. This makes lookup by the `getStringAssignment` function very fast. The configuration data stored contains the experiment key, experiment variation values, traffic allocation, and any allow-list overrides.
+The SDK uses `@react-native-async-storage` to store experiment configurations downloaded from Eppo. This makes lookup by the `get<Type>Assignment` functions very fast. The configuration data stored contains the experiment key, experiment variation values, and allocations.

--- a/docs/sdks/client-sdks/react-native.md
+++ b/docs/sdks/client-sdks/react-native.md
@@ -113,7 +113,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional map of subject metadata for targeting.
   }
@@ -124,7 +124,7 @@ The `getStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 
@@ -199,7 +199,7 @@ After the SDK is initialized, you may assign variations from any child component
 function MyComponent(): JSX.Element {
   const assignedVariation = useMemo(() => {
     const eppoClient = getInstance();
-    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", "<DEFAULT-VARIATION>");
+    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", "<DEFAULT-VALUE>");
   }, []);
 
   return (

--- a/docs/sdks/datadog.md
+++ b/docs/sdks/datadog.md
@@ -55,7 +55,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FEATURE-FLAG-KEY>",
-  "<DEFAULT-VARIATION>"
+  "<DEFAULT-VALUE>"
 );
 ```
 

--- a/docs/sdks/datadog.md
+++ b/docs/sdks/datadog.md
@@ -54,7 +54,8 @@ await init({
 const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
-  "<FEATURE-FLAG-KEY>"
+  "<FEATURE-FLAG-KEY>",
+  "<DEFAULT-VARIATION>"
 );
 ```
 

--- a/docs/sdks/event-logging.md
+++ b/docs/sdks/event-logging.md
@@ -70,6 +70,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -111,6 +112,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -157,6 +159,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -220,6 +223,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -258,6 +262,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional metadata about the user to be used for targeting
   }

--- a/docs/sdks/event-logging.md
+++ b/docs/sdks/event-logging.md
@@ -70,7 +70,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -112,7 +112,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -159,7 +159,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -223,7 +223,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional metadata about the user to be used for targeting
   }
@@ -262,7 +262,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional metadata about the user to be used for targeting
   }

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -10,14 +10,14 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional map of subject metadata for targeting.
   }
 );
 ```
 
-Here, `SUBJECT-KEY` is a unique identifier for the unit on which you are assigning (e.g., `user_id`). `FLAG-KEY` is a unique identifier for the feature of interest (e.g., `new_user_onboarding`). `DEFAULT-VARIATION` is the variation that will be returned if no allocation matches the subject, if the flag is not enabled, or if the SDK was not able to retrieve the flag configuration. The optional fourth argument provides subject-level properties for targeting.
+Here, `SUBJECT-KEY` is a unique identifier for the unit on which you are assigning (e.g., `user_id`). `FLAG-KEY` is a unique identifier for the feature of interest (e.g., `new_user_onboarding`). `DEFAULT-VALUE` is the value that will be returned if no allocation matches the subject, if the flag is not enabled, or if the SDK was not able to retrieve the flag configuration. The optional fourth argument provides subject-level properties for targeting.
 
 For experimentation use cases, Eppo uses a deterministic hashing function to ensure that the same variant is returned for a given `SUBJECT-KEY`. This guarantee also holds across different SDKs. That is, experiment assignments from a server SDK will be consistent with experiment assignments from a client SDK for the same `SUBJECT-KEY`.
 

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -10,13 +10,14 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional map of subject metadata for targeting.
   }
 );
 ```
 
-Here, `SUBJECT-KEY` is a unique identifier for the unit on which you are assigning (e.g., `user_id`) and `FLAG-KEY` is a unique identifier for the feature of interest (e.g., `new_user_onboarding`). The optional third argument provides subject-level properties for targeting.
+Here, `SUBJECT-KEY` is a unique identifier for the unit on which you are assigning (e.g., `user_id`). `FLAG-KEY` is a unique identifier for the feature of interest (e.g., `new_user_onboarding`). `DEFAULT-VARIATION` is the variation that will be returned if no allocation matches the subject, if the flag is not enabled, or if the SDK was not able to retrieve the flag configuration. The optional fourth argument provides subject-level properties for targeting.
 
 For experimentation use cases, Eppo uses a deterministic hashing function to ensure that the same variant is returned for a given `SUBJECT-KEY`. This guarantee also holds across different SDKs. That is, experiment assignments from a server SDK will be consistent with experiment assignments from a client SDK for the same `SUBJECT-KEY`.
 

--- a/docs/sdks/sdk-features/bandits.md
+++ b/docs/sdks/sdk-features/bandits.md
@@ -51,7 +51,7 @@ Map<String, EppoAttributes> actionsWithAttributes = Map.of(
   "size", EppoValue.valueOf("small")
 ))
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actionsWithAttributes);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultValue, subjectAttributes, actionsWithAttributes);
 ```
 
 If the actions don't have attributes for the context, you can simply provide a set of actions without attributes:
@@ -59,7 +59,7 @@ If the actions don't have attributes for the context, you can simply provide a s
 ```java
 Set<String> actions = Set.of("dog", "cat", "bird", "goldfish");
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actions);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultValue, subjectAttributes, actions);
 ```
 
 ## Logging bandit assignments

--- a/docs/sdks/sdk-features/bandits.md
+++ b/docs/sdks/sdk-features/bandits.md
@@ -51,7 +51,7 @@ Map<String, EppoAttributes> actionsWithAttributes = Map.of(
   "size", EppoValue.valueOf("small")
 ))
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithAttributes);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actionsWithAttributes);
 ```
 
 If the actions don't have attributes for the context, you can simply provide a set of actions without attributes:
@@ -59,7 +59,7 @@ If the actions don't have attributes for the context, you can simply provide a s
 ```java
 Set<String> actions = Set.of("dog", "cat", "bird", "goldfish");
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, subjectAttributes, actions);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actions);
 ```
 
 ## Logging bandit assignments

--- a/docs/sdks/sdk-features/flag-types.md
+++ b/docs/sdks/sdk-features/flag-types.md
@@ -7,9 +7,9 @@ The [Javascript client SDK](/sdks/client-sdks/javascript) for example has the fo
 ```
 getStringAssignment(...)
 getBoolAssignment(...)
+getIntegerAssignment(...)
 getNumericAssignment(...)
-getJSONStringAssignment(...)
-getParsedJSONAssignment(...)
+getJSONAssignment(...)
 ```
 
-The function names differ slightly according to naming conventions in the respective SDK languages. The function used to get the assignment must match the type of the feature flag. To get assignments for a JSON-type feature flag being used as a dynamic config, for example, you would use `getJSONStringAssignment` or `getParsedJSONAssignment`, whereas incorrectly calling `getNumericAssignment` would return `null` and no assignments would occur.
+The function names differ slightly according to naming conventions in the respective SDK languages. The function used to get the assignment must match the type of the feature flag. To get assignments for a JSON-typed feature flag being used as a dynamic config, for example, you would use `getJSONAssignment`, whereas incorrectly calling `getNumericAssignment` would return the default variation and no assignments would occur.

--- a/docs/sdks/sdk-features/obfuscation.md
+++ b/docs/sdks/sdk-features/obfuscation.md
@@ -45,6 +45,8 @@ The `value` field in `conditions` may or may not be hashed depending on the conf
 | greater than (>)           | encoded |
 | greater than or equal (>=) | encoded |
 | matches regex              | encoded |
+| is null                    | n/a     |
+| is not null                | n/a     |
 
 The targeting rule's `operator` is configured in the UI during allocation setup.
 

--- a/docs/sdks/sdk-features/obfuscation.md
+++ b/docs/sdks/sdk-features/obfuscation.md
@@ -40,13 +40,12 @@ The `value` field in `conditions` may or may not be hashed depending on the conf
 | -------------------------- | ------- |
 | is one of                  | hashed  |
 | is not one of              | hashed  |
+| is null                    | hashed  |
 | less than (<)              | encoded |
 | less than or equal (<=)    | encoded |
 | greater than (>)           | encoded |
 | greater than or equal (>=) | encoded |
 | matches regex              | encoded |
-| is null                    | n/a     |
-| is not null                | n/a     |
 
 The targeting rule's `operator` is configured in the UI during allocation setup.
 

--- a/docs/sdks/sdk-features/subject-attributes.md
+++ b/docs/sdks/sdk-features/subject-attributes.md
@@ -18,7 +18,8 @@ import * as EppoSdk from "@eppo/js-client-sdk";
 const subjectAttributes = { device: "iOS" };
 const variation = EppoSdk.getInstance().getStringAssignment(
   "<SUBJECT-KEY>",
-  "<EXPERIMENT-KEY>",
+  "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   subjectAttributes
 );
 ```
@@ -33,7 +34,8 @@ import * as EppoSdk from "@eppo/node-server-sdk";
 const subjectAttributes = { device: "iOS" };
 const variation = EppoSdk.getInstance().getStringAssignment(
   "<SUBJECT-KEY>",
-  "<EXPERIMENT-KEY>",
+  "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   subjectAttributes
 );
 ```
@@ -46,7 +48,12 @@ const variation = EppoSdk.getInstance().getStringAssignment(
 import eppo_client
 
 client = eppo_client.get_instance()
-variation = client.get_string_assignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>", { "device": "iOS" })
+variation = client.get_string_assignment(
+  "<SUBJECT-KEY>",
+  "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
+  { "device": "iOS" }
+)
 ```
 
 </TabItem>

--- a/docs/sdks/sdk-features/subject-attributes.md
+++ b/docs/sdks/sdk-features/subject-attributes.md
@@ -19,7 +19,7 @@ const subjectAttributes = { device: "iOS" };
 const variation = EppoSdk.getInstance().getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   subjectAttributes
 );
 ```
@@ -35,7 +35,7 @@ const subjectAttributes = { device: "iOS" };
 const variation = EppoSdk.getInstance().getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   subjectAttributes
 );
 ```
@@ -51,7 +51,7 @@ client = eppo_client.get_instance()
 variation = client.get_string_assignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   { "device": "iOS" }
 )
 ```

--- a/docs/sdks/server-sdks/dotnet.md
+++ b/docs/sdks/server-sdks/dotnet.md
@@ -75,7 +75,7 @@ For example, for a String-valued flag, use `GetStringAssignment`:
 var assignedVariation = eppoClient.GetStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {} // Optional Dictionary of subject metadata for targeting.
 );
 ```
@@ -84,7 +84,7 @@ The `GetStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `GetStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `Get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `GetStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `Get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 The following typed functions are available:

--- a/docs/sdks/server-sdks/dotnet.md
+++ b/docs/sdks/server-sdks/dotnet.md
@@ -68,40 +68,33 @@ More details about logging and examples (with Segment, Rudderstack, mParticle, a
 
 ## 3. Assign variations
 
-Assigning users to flags or experiments with a single `GetStringAssignment` function:
+Assign users to flags or experiments using `Get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `GetStringAssignment`:
 
 ```csharp
-var assignedVariation = eppoClient.GetStringAssignment("<SUBJECT-KEY>", "<FLAG-KEY>", {
-  // Optional Dictionary of subject metadata for targeting.
-});
+var assignedVariation = eppoClient.GetStringAssignment(
+  "<SUBJECT-KEY>",
+  "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
+  {} // Optional Dictionary of subject metadata for targeting.
+);
 ```
 
-The `GetStringAssignment` function takes two required and one optional input to assign a variation:
+The `GetStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
-- `targetingAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `GetStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `Get<Type>Assignment` call.
+- `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
-Starting in version `v2.0.0` typed functions are available:
-
+The following typed functions are available:
 ```
-eppoClient.GetBoolAssignment(string subjectKey, string flagKey, SubjectAttributes? subjectAttributes = null)
-eppoClient.GetNumericAssignment(string subjectKey, string flagKey, SubjectAttributes? subjectAttributes = null)
+GetBoolAssignment(...)
+GetNumericAssignment(...)
+GetIntegerAssignment(...)
+GetStringAssignment(...)
+GetJSONAssignment(...)
 ```
-
-### Handling the null assignment
-
-We recommend always handling the empty assignment case in your code. Here are some examples illustrating when the SDK returns `null`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `null` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `null` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3.  If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `null` if no configurations have been downloaded.
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.

--- a/docs/sdks/server-sdks/go.md
+++ b/docs/sdks/server-sdks/go.md
@@ -113,7 +113,7 @@ var eppoClient = &eppoclient.EppoClient{} // in global scope
 variation := eppoClient.GetStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   <TARGETING_ATTRIBUTES>
   );
 ```
@@ -122,7 +122,7 @@ The `GetStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `GetStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `Get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `GetStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `Get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 

--- a/docs/sdks/server-sdks/go.md
+++ b/docs/sdks/server-sdks/go.md
@@ -102,46 +102,41 @@ More details about logging and examples (with Segment, Rudderstack, mParticle, a
 
 ## 3. Assign variations
 
-Assigning users to flags or experiments with a single `GetStringAssignment` function:
-
+Assign users to flags or experiments using `Get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `GetStringAssignment`:
 ```go
 import (
 	"github.com/Eppo-exp/golang-sdk/v2/eppoclient"
 )
 
 var eppoClient = &eppoclient.EppoClient{} // in global scope
-variation := eppoClient.GetStringAssignment("<SUBJECT-KEY>", "<FLAG-KEY>", <TARGETING_ATTRIBUTES>);
+variation := eppoClient.GetStringAssignment(
+  "<SUBJECT-KEY>",
+  "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
+  <TARGETING_ATTRIBUTES>
+  );
 ```
 
-The `GetStringAssignment` function takes two required and one optional input to assign a variation:
+The `GetStringAssignment` function takes three required and one optional input to assign a variation:
 
-- `subjectKey` - The ID of the entity that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
-- `targetingAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+- `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
+- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `GetStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `Get<Type>Assignment` call.
+- `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+
 
 ### Typed assignments
 
-Additional functions are available:
+The following typed functions are available:
 
 ```
-GetBoolAssignment(...)
-GetNumericAssignment(...)
-GetJSONStringAssignment(...)
+getBoolAssignment(...)
+getNumericAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
-
-### Handling the empty assignment
-
-We recommend always handling the empty assignment case, when the SDK returns `""`. Here are some examples illustrating when the SDK returns `""`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `""` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `""` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3.  If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `""` if no configurations have been downloaded.
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.

--- a/docs/sdks/server-sdks/java.md
+++ b/docs/sdks/server-sdks/java.md
@@ -77,7 +77,7 @@ For example, for a String-valued flag, use `getStringAssignment`:
 Optional<String> assignedVariation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>", 
+  "<DEFAULT-VALUE>", 
   {} // Optional map of subject metadata for targeting.
 );
 ```
@@ -86,7 +86,7 @@ The `getStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 
@@ -215,7 +215,7 @@ model evolves.
 ```java
 // Flag that has a bandit variation
 String banditTestFlagKey = "bandit-test";
-String defaultVariation = "control";
+String defaultValue = "control";
 
 // Subject information--same as for retrieving simple flag or experiment assignments
 String subjectKey = username;
@@ -240,7 +240,7 @@ Map<String, EppoAttributes> actionsWithAttributes = Map.of(
   "size", EppoValue.valueOf("small")
 ))
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actionsWithAttributes);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultValue, subjectAttributes, actionsWithAttributes);
 ```
 
 ### Logging non-bandit actions (contextual multi-armed bandit assignment only)
@@ -254,7 +254,7 @@ The code below illustrates an example use of this.
 
 ```java
 
-Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultVariation, subjectAttributes, actionsWithAttributes);
+Optional<String> banditAssignment = eppoClient.getStringAssignment(subjectKey, flagKey, defaultValue, subjectAttributes, actionsWithAttributes);
 
 boolean doControlAction = banditAssignment.isEmpty() || banditAssignment.get().equals("control");
 

--- a/docs/sdks/server-sdks/node.md
+++ b/docs/sdks/server-sdks/node.md
@@ -233,7 +233,8 @@ After initialization, the SDK begins polling Eppo’s API at regular intervals t
 
 ### Assign variations
 
-Assigning users to flags or experiments with a single `getStringAssignment` function:
+Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `getStringAssignment`:
 
 ```javascript
 import * as EppoSdk from "@eppo/node-server-sdk";
@@ -242,17 +243,20 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
+  "<DEFAULT-VARIATION>",
   {
     // Optional map of subject metadata for targeting.
   }
 );
 ```
 
-The `getStringAssignment` function takes two required and one optional input to assign a variation:
+The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
+- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+
 
 ### Example
 
@@ -285,6 +289,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   user.userid,
   "new-user-onboarding",
+  "control",
   user.attributes
 );
 ```
@@ -303,35 +308,20 @@ const variation = eppoClient.getStringAssignment(
 }
 ```
 
-
-
-## Handling `null`
-
-We recommend always handling the `null` case in your code. Here are some examples illustrating when the SDK returns `null`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `null` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `null` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `null` if no configurations have been downloaded.
-
-<br />
-
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
 :::
 
 ## Typed assignments
 
-Use the following `get<Type>Assignment` methods for the type of feature flag created:
+The following typed functions are available:
 
 ```
 getBoolAssignment(...)
 getNumericAssignment(...)
-getJSONStringAssignment(...)
-getParsedJSONAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
 To read more about different flag types, see the page on [Flag Variations](/feature-flagging/flag-variations).
 ## Initialization options

--- a/docs/sdks/server-sdks/node.md
+++ b/docs/sdks/server-sdks/node.md
@@ -243,7 +243,7 @@ const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
   "<SUBJECT-KEY>",
   "<FLAG-KEY>",
-  "<DEFAULT-VARIATION>",
+  "<DEFAULT-VALUE>",
   {
     // Optional map of subject metadata for targeting.
   }
@@ -254,7 +254,7 @@ The `getStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 

--- a/docs/sdks/server-sdks/php.md
+++ b/docs/sdks/server-sdks/php.md
@@ -104,7 +104,8 @@ More details about logging and examples (with Segment, Rudderstack, mParticle, a
 
 ## 3. Assign variations
 
-Assigning users to flags or experiments with a single `getStringAssignment` function:
+Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `getStringAssignment`:
 
 ```php
 <?php
@@ -121,7 +122,12 @@ $eppoClient = EppoClient::init(
 );
 
 $subjectAttributes = [];
-$variation = $eppoClient->getStringAssignment('subject-1', 'experiment_5', $subjectAttributes);
+$variation = $eppoClient->getStringAssignment(
+  'subject-1', // subject key
+  'experiment_5', // flag key
+  'control', // default variation
+  $subjectAttributes
+);
 
 if ($variation === 'control') {
     // do something
@@ -129,34 +135,25 @@ if ($variation === 'control') {
 
 ```
 
-The `getStringAssignment` function takes two required and one optional input to assign a variation:
+The `getStringAssignment` function takes three required and one optional input to assign a variation:
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
+- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
+
 
 ### Typed assignments
 
-Additional functions are available:
+The following typed functions are available:
 
 ```
-getBooleanAssignment(...)
+getBoolAssignment(...)
 getNumericAssignment(...)
-getJSONStringAssignment(...)
-getParsedJSONAssignment(...)
+getIntegerAssignment(...)
+getStringAssignment(...)
+getJSONAssignment(...)
 ```
-
-### Handling the empty assignment
-
-We recommend always handling the empty assignment case, when the SDK returns `""`. Here are some examples illustrating when the SDK returns `""`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `""` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `""` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.

--- a/docs/sdks/server-sdks/php.md
+++ b/docs/sdks/server-sdks/php.md
@@ -139,7 +139,7 @@ The `getStringAssignment` function takes three required and one optional input t
 
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
 - `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
-- `defaultVariation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
+- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
 - `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -37,11 +37,12 @@ This generates a singleton client instance that can be reused throughout the app
 
 ### C. Assign variations
 
-This instance can then be called to assign users to flags or experiments using the `get_string_assignment` function:
+Assign users to flags or experiments using `get_<type>_assignment`, depending on the type of the flag.
+For example, for a String-valued flag, use `get_string_assignment`:
 
 ```python
 …
-variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-KEY>")
+variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-KEY>", "<DEFAULT-VARIATION>")
 if variation == "fast_checkout":
     …
 else:
@@ -49,6 +50,7 @@ else:
 ```
 * `<SUBJECT-KEY>` is the value that identifies each entity in your experiment, typically `user_id`;
 * `<FLAG-KEY>` is the key that you chose when creating a flag; you can find it on the [flag page](https://eppo.cloud/feature-flags). For the rest of this presentation, we’ll use `"test-checkout"`. To follow along, we recommend that you create a test flag in your account, and split users between `"fast_checkout"` and `"standard_checkout"`.
+* `<DEFAULT-VARIATION>` is the value that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
 
 Here's how this configuration looks in the [flag page](https://eppo.cloud/feature-flags):
 
@@ -98,7 +100,7 @@ client = eppo_client.get_instance()
 # Give the client some time to initialize.
 # Note that the client may get stuck on this step if there are errors.
 # Please refer to the logs.
-while client.get_string_assignment('0', "test-checkout") is None:
+while client.get_string_assignment('0', "test-checkout", "standard_checkout") is None:
     print("Waiting for client to initialize. Check the logs if this message persists.")
     sleep(1)
 # In a real-world scenario, other modules would load
@@ -107,7 +109,7 @@ while client.get_string_assignment('0', "test-checkout") is None:
 for _ in range(10):
     # Randomly creating user ids. Note that they might not actually exist in your experiment.
     user_id = str(uuid4())
-    variation = client.get_string_assignment(user_id, "test-checkout")
+    variation = client.get_string_assignment(user_id, "test-checkout", "standard_checkout")
     if variation == "fast_checkout":
         print(f"{user_id}: Fast checkout")
     elif variation == "standard_checkout":
@@ -193,17 +195,6 @@ Changes made to experiments on Eppo’s web interface are almost instantly propa
 
 :::
 
-### C. Handling `None`
-
-To be safe, we recommend always handling the `None` case in your code. Here are some examples illustrating when the SDK might return `None`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `None` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must **enable the environment** corresponding to the feature flag’s allocation in the [flag control panel](https://eppo.cloud/feature-flags/) before `getStringAssignment` returns variations. It will return `None` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `get_string_assignment` is invoked **before the SDK has finished initializing**, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will return `None`.
 
 :::info
 
@@ -214,10 +205,11 @@ By default, the Eppo client initialization is asynchronous to ensure no critical
 
 ## 4. Advanced Configuration with Metadata
 
-We introduced `get_string_assignment`’s two required inputs in the [Getting started](#getting-started) section:
+We introduced `get_string_assignment`’s three required inputs in the [Getting started](#getting-started) section:
 
 - `subject_key`: The Entity ID that is being experimented on, typically represented by a uuid.
 - `flag_key`: This key is available on the detail page for both flags and experiments.
+- `default_variation`: The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
 
 But that’s not all: the function also takes an optional input for entity properties.
 
@@ -261,6 +253,7 @@ if request.method == 'POST':
     variation = client.get_string_assignment(
         "<SUBJECT-KEY>",
         "<FLAG-KEY>",
+        "<DEFAULT-VARIATION>",
         session_attributes,
     )
     
@@ -283,23 +276,24 @@ If you create rules based on attributes on a flag or an experiment, those attrib
 
 ## 5. Typed Assignment Calls
 
-The SDK also offers assignment calls for other assignment types.
+The following typed functions are available:
 
 ```
 get_boolean_assignment(...)
+get_integer_assignment(...)
 get_numeric_assignment(...)
-get_json_string_assignment(...)
-get_parsed_json_assignment(...)
+get_string_assignment(...)
+get_json_assignment(...)
 ```
 
-Those take the same input as `get_string_assignment`: `subject_key`, `flag_key` and `subject_attributes`.
+All take the same input: `subject_key`, `flag_key`, `default_variation`, and (optionally) `subject_attributes`.
 
 ### A. Boolean Assignment
 
 For example, if you configure a flag as a Boolean (`True` or `False`), you can simplify your code:
 
 ```python
-if get_boolean_assignment("<SUBJECT-KEY>", "<FLAG-KEY>"):
+if get_boolean_assignment("<SUBJECT-KEY>", "<FLAG-KEY>", False):
     …
 else:
     …
@@ -309,15 +303,15 @@ That prevents having the option of a third output. However, `“True”` can be 
 
 ### B. Numeric Assignment
 
-If you want to modify a quantity, say, the number of columns of your layout, the number of product recommendations per page or the minimum spent for free delivery, you want to make sure the allocation value is a number. Using a numeric-valued flag and `get_numeric_assignment` guarantees that. When someone edits the assignment, it will remain a number. This is useful if you are using that value in computation, say to process the amount of a promotion. It will capture obvious configuration issues before they are rolled-out.
+If you want to modify a quantity, say, the number of columns of your layout, the number of product recommendations per page or the minimum spent for free delivery, you want to make sure the allocation value is a number. Using a numeric-valued flag and `get_numeric_assignment` guarantees that. (If you want to ensure that the value be specifically an integer, use an integer-valued flag and `get_integer_assignment`.) When someone edits the assignment, it will remain a number. This is useful if you are using that value in computation, say to process the amount of a promotion. It will capture obvious configuration issues before they are rolled out.
 
-### C. Parsed JSON Assignment
+### C. JSON Assignment
 
 A more interesting pattern is to assign a JSON object. This allows us to include structured information, say the text of a marketing copy for a promotional campaign and the address of a hero image. Thanks to this pattern, one developer can configure a very simple landing page; with that in place, whoever has access to the feature flag configuration can decide and change what copy to show to users throughout a promotional period, almost instantly and without them having to release new code.
 
 ```python
 …
-self.campaign_json = get_parsed_json_assignment("<SUBJECT-KEY>", "<FLAG-KEY>")
+self.campaign_json = get_json_assignment("<SUBJECT-KEY>", "<FLAG-KEY>", <DEFAULT-JSON>)
 if self.campaign_json is not None:
     campaign['hero'] = True
     campaign['hero_image'] = self.campaign_json.hero_image
@@ -327,7 +321,3 @@ if self.campaign_json is not None:
 ```
 
 Assuming your service can be configured with many input parameters, that assignment type enables very powerful configuration changes.
-
-### D. String JSON Assignment
-
-`get_json_string_assignment` is similar, but the output is a string. This adds the responsibility of unpacking the JSON from that string.

--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -42,7 +42,7 @@ For example, for a String-valued flag, use `get_string_assignment`:
 
 ```python
 …
-variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-KEY>", "<DEFAULT-VARIATION>")
+variation = client.get_string_assignment("<SUBJECT-KEY>", "<FLAG-KEY>", "<DEFAULT-VALUE>")
 if variation == "fast_checkout":
     …
 else:
@@ -50,7 +50,7 @@ else:
 ```
 * `<SUBJECT-KEY>` is the value that identifies each entity in your experiment, typically `user_id`;
 * `<FLAG-KEY>` is the key that you chose when creating a flag; you can find it on the [flag page](https://eppo.cloud/feature-flags). For the rest of this presentation, we’ll use `"test-checkout"`. To follow along, we recommend that you create a test flag in your account, and split users between `"fast_checkout"` and `"standard_checkout"`.
-* `<DEFAULT-VARIATION>` is the value that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
+* `<DEFAULT-VALUE>` is the value that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
 
 Here's how this configuration looks in the [flag page](https://eppo.cloud/feature-flags):
 
@@ -209,7 +209,7 @@ We introduced `get_string_assignment`’s three required inputs in the [Getting 
 
 - `subject_key`: The Entity ID that is being experimented on, typically represented by a uuid.
 - `flag_key`: This key is available on the detail page for both flags and experiments.
-- `default_variation`: The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
+- `default_value`: The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
 
 But that’s not all: the function also takes an optional input for entity properties.
 
@@ -253,7 +253,7 @@ if request.method == 'POST':
     variation = client.get_string_assignment(
         "<SUBJECT-KEY>",
         "<FLAG-KEY>",
-        "<DEFAULT-VARIATION>",
+        "<DEFAULT-VALUE>",
         session_attributes,
     )
     
@@ -286,7 +286,7 @@ get_string_assignment(...)
 get_json_assignment(...)
 ```
 
-All take the same input: `subject_key`, `flag_key`, `default_variation`, and (optionally) `subject_attributes`.
+All take the same input: `subject_key`, `flag_key`, `default_value`, and (optionally) `subject_attributes`.
 
 ### A. Boolean Assignment
 

--- a/docs/sdks/server-sdks/ruby.md
+++ b/docs/sdks/server-sdks/ruby.md
@@ -89,7 +89,7 @@ client = EppoClient::Client.instance
 variation = client.get_string_assignment(
   '<SUBJECT-KEY>',
   '<FLAG-KEY>',
-  '<DEFAULT-VARIATION>',
+  '<DEFAULT-VALUE>',
   {
     # Optional map of subject metadata for targeting.
   }
@@ -133,7 +133,7 @@ client = EppoClient::Client.instance
 variation = client.get_string_assignment(
   '<SUBJECT-KEY>',
   '<FLAG-KEY>',
-  '<DEFAULT-VARIATION>',
+  '<DEFAULT-VALUE>',
   {},
   Logger::DEBUG
 )

--- a/docs/sdks/server-sdks/ruby.md
+++ b/docs/sdks/server-sdks/ruby.md
@@ -89,11 +89,19 @@ client = EppoClient::Client.instance
 variation = client.get_string_assignment(
   '<SUBJECT-KEY>',
   '<FLAG-KEY>',
+  '<DEFAULT-VARIATION>',
   {
     # Optional map of subject metadata for targeting.
   }
 )
 ```
+
+The `get_string_assignment` function takes three required and one optional input to assign a variation:
+
+- `subject_key` - The entity ID that is being experimented on, typically represented by a uuid.
+- `flag_key` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
+- `default_variation` - The variation that will be returned if no allocation matches the subject, if the flag is not enabled, if `get_string_assignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration.
+- `subject_attributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 The `get_string_assignment` function takes two required and one optional input to assign a variation:
 
@@ -103,30 +111,19 @@ The `get_string_assignment` function takes two required and one optional input t
 
 ### Typed assignments
 
-Additional functions are available:
+The following typed functions are available:
 
 ```
 get_boolean_assignment(...)
+get_integer_assignment(...)
 get_numeric_assignment(...)
-get_json_string_assignment(...)
-get_parsed_json_assignment(...)
+get_string_assignment(...)
+get_json_assignment(...)
 ```
 
-### Handling `nil`
+### Debugging
 
-We recommend always handling the `nil` case in your code. Here are some examples of when the SDK returns `nil`:
-
-1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `nil` for the remaining 75% (unless the subject is part of an allow list).
-
-2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `nil` if the environment is not enabled.
-
-![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
-
-3. If `get_string_assignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `nil` if no configurations have been downloaded.
-
-### Debugging `nil`
-
-If you need more visibility into why `get_string_assignment` is returning `nil`, you can change the logging level to `Logger::DEBUG` to see more details in the standard output.
+If you need more visibility into why `get_string_assignment` is returning a certain value, you can change the logging level to `Logger::DEBUG` to see more details in the standard output.
 
 ```ruby
 require 'eppo_client'
@@ -136,12 +133,11 @@ client = EppoClient::Client.instance
 variation = client.get_string_assignment(
   '<SUBJECT-KEY>',
   '<FLAG-KEY>',
+  '<DEFAULT-VARIATION>',
   {},
   Logger::DEBUG
 )
 ```
-
-<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.


### PR DESCRIPTION
Companion to https://github.com/Eppo-exp/eppo-docs/pull/338. This will stay in draft state. Updates can be pulled from here as more SDKs are updated.