### PR TITLE
Fix broken links in SDK documentation

### DIFF
--- a/docs/sdks/client-sdks/index.md
+++ b/docs/sdks/client-sdks/index.md
@@ -18,7 +18,7 @@ The SDK uses a background process to fetch and store the experiment data. The p7
 
 ### Language-specific Documentation
 
-- [JavaScript](./javascript)
-- [React Native](./react-native)
-- [Android](./android)
-- [iOS](./ios)
+- [JavaScript](/sdks/client-sdks/javascript)
+- [React Native](/sdks/client-sdks/react-native)
+- [Android](/sdks/client-sdks/android)
+- [iOS](/sdks/client-sdks/ios)

--- a/docs/sdks/server-sdks/index.md
+++ b/docs/sdks/server-sdks/index.md
@@ -13,7 +13,7 @@ Eppo's server-side SDKs may be used to implement flags and run experiments in yo
 ### Language-specific Documentation
 
 - [Node](./node)
-- [Python](./python)
+- [Python](./python.md)
 - [Java](./java)
 - [Dot Net](./dotnet)
 - [Go](./go)

--- a/docs/sdks/server-sdks/index.md
+++ b/docs/sdks/server-sdks/index.md
@@ -12,10 +12,10 @@ Eppo's server-side SDKs may be used to implement flags and run experiments in yo
 
 ### Language-specific Documentation
 
-- [Node](./node)
-- [Python](./python.md)
-- [Java](./java)
-- [Dot Net](./dotnet)
-- [Go](./go)
-- [Ruby](./ruby)
-- [PHP](./php)
+- [Node](/sdks/client-sdks/node)
+- [Python](/sdks/server-sdks/python)
+- [Java](/sdks/server-sdks/java)
+- [Dot Net](/sdks/server-sdks/dotnet)
+- [Go](/sdks/server-sdks/go)
+- [Ruby](/sdks/server-sdks/ruby)
+- [PHP](/sdks/server-sdks/php)

--- a/docs/sdks/server-sdks/index.md
+++ b/docs/sdks/server-sdks/index.md
@@ -12,7 +12,7 @@ Eppo's server-side SDKs may be used to implement flags and run experiments in yo
 
 ### Language-specific Documentation
 
-- [Node](/sdks/client-sdks/node)
+- [Node](/sdks/server-sdks/node)
 - [Python](/sdks/server-sdks/python)
 - [Java](/sdks/server-sdks/java)
 - [Dot Net](/sdks/server-sdks/dotnet)


### PR DESCRIPTION
I noticed some strange behavior in our docs. If you navigate directly to the Server SDK page (i.e. click on this [link](https://docs.geteppo.com/sdks/server-sdks)), and then scroll down and click on one of the languages, it routes you to a broken link (e.g. https://docs.geteppo.com/sdks/python). 

However, if you navigate to the same page by clicking "Server SDKs" in the sidebar, it works as expected. I suspect this is due to quirks with relative paths. I changed the references to absolute paths in this PR and that seems to fix the issue.

Ditto for Client SDKs.

![image](https://github.com/Eppo-exp/eppo-docs/assets/24952168/a4094137-0099-4dae-aee7-781c06beaa82)
