### PR TITLE
Revert changes to react-native to pre-v3 state

### DIFF
--- a/docs/sdks/client-sdks/react-native.md
+++ b/docs/sdks/client-sdks/react-native.md
@@ -103,40 +103,51 @@ Eppo's SDK uses an internal cache to ensure that duplicate assignment events are
 
 ## 3. Assign variations
 
-Assign users to flags or experiments using `get<Type>Assignment`, depending on the type of the flag.
-For example, for a String-valued flag, use `getStringAssignment`:
+Assigning users to flags or experiments with a single `getStringAssignment` function:
 
 ```javascript
 import * as EppoSdk from "@eppo/react-native-sdk";
 
 const eppoClient = EppoSdk.getInstance();
 const variation = eppoClient.getStringAssignment(
-  "<FLAG-KEY>",
   "<SUBJECT-KEY>",
-  <SUBJECT-ATTRIBUTES>, // Metadata used for targeting
-  "<DEFAULT-VALUE>",
+  "<FLAG-KEY>",
+  {
+    // Optional map of subject metadata for targeting.
+  }
 );
 ```
 
-The `getStringAssignment` function takes three required and one optional input to assign a variation:
+The `getStringAssignment` function takes two required and one optional input to assign a variation:
 
-- `flagKey` - This key is available on the detail page for both flags and experiments. Can also be an experiment key.
 - `subjectKey` - The entity ID that is being experimented on, typically represented by a uuid.
-- `subjectAttributes` - A map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call. If no attributes are needed, pass in an empty object.
-- `defaultValue` - The value that will be returned if no allocation matches the subject, if the flag is not enabled, if `getStringAssignment` is invoked before the SDK has finished initializing, or if the SDK was not able to retrieve the flag configuration. Its type must match the `get<Type>Assignment` call.
-
+- `flagOrExperimentKey` - This key is available on the detail page for both flags and experiments.
+- `subjectAttributes` - An optional map of metadata about the subject used for targeting. If you create rules based on attributes on a flag/experiment, those attributes should be passed in on every assignment call.
 
 ### Typed assignments
 
-The following typed functions are available:
+Additional functions are available:
 
-```javascript
+```
 getBoolAssignment(...)
 getNumericAssignment(...)
-getIntegerAssignment(...)
-getStringAssignment(...)
-getJSONAssignment(...)
+getJSONStringAssignment(...)
+getParsedJSONAssignment(...)
 ```
+
+### Handling `null`
+
+We recommend always handling the `null` case in your code. Here are some examples illustrating when the SDK returns `null`:
+
+1. The **Traffic Exposure** setting on experiments/allocations determines the percentage of subjects the SDK will assign to that experiment/allocation. For example, if Traffic Exposure is 25%, the SDK will assign a variation for 25% of subjects and `null` for the remaining 75% (unless the subject is part of an allow list).
+
+2. Assignments occur within the environments of feature flags. You must enable the environment corresponding to the feature flag's allocation in the user interface before `getStringAssignment` returns variations. It will return `null` if the environment is not enabled.
+
+![Toggle to enable environment](/img/feature-flagging/enable-environment.png)
+
+3. If `getStringAssignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent experiment configurations. In this case, the SDK will assign a variation based on any previously downloaded experiment configurations stored in local storage, or return `null` if no configurations have been downloaded.
+
+<br />
 
 :::note
 It may take up to 10 seconds for changes to Eppo experiments to be reflected by the SDK assignments.
@@ -197,7 +208,7 @@ After the SDK is initialized, you may assign variations from any child component
 function MyComponent(): JSX.Element {
   const assignedVariation = useMemo(() => {
     const eppoClient = getInstance();
-    return eppoClient.getStringAssignment("<FLAG-KEY>", "<SUBJECT-KEY>", <SUBJECT-ATTRIBUTES>, "<DEFAULT-VALUE>");
+    return eppoClient.getStringAssignment("<SUBJECT-KEY>", "<EXPERIMENT-KEY>");
   }, []);
 
   return (
@@ -210,4 +221,4 @@ function MyComponent(): JSX.Element {
 
 ### Local Storage
 
-The SDK uses `@react-native-async-storage` to store experiment configurations downloaded from Eppo. This makes lookup by the `get<Type>Assignment` functions very fast. The configuration data stored contains the experiment key, experiment variation values, and allocations.
+The SDK uses `@react-native-async-storage` to store experiment configurations downloaded from Eppo. This makes lookup by the `getStringAssignment` function very fast. The configuration data stored contains the experiment key, experiment variation values, traffic allocation, and any allow-list overrides.


### PR DESCRIPTION
The docs for React Native were prematurely updated. The [SDK](https://github.com/Eppo-exp/react-native-sdk) hasn't yet been updated to v3. This PR reverts the change to the docs to make sure that the docs and the latest version of the SDK are matched. 