### PR TITLE
feat: enable highlighting for more languages

### DIFF
--- a/docs/sdks/server-sdks/java.md
+++ b/docs/sdks/server-sdks/java.md
@@ -12,7 +12,7 @@ Eppo's open source Java SDK can be used for both feature flagging and experiment
 
 In your pom.xml, add the SDK package as a dependency:
 
-```
+```xml
 <dependency>
   <groupId>cloud.eppo</groupId>
   <artifactId>eppo-server-sdk</artifactId>

--- a/docs/sdks/server-sdks/php.md
+++ b/docs/sdks/server-sdks/php.md
@@ -12,7 +12,7 @@ Eppo's open source PHP SDK can be used for both feature flagging and experiment 
 
 Run
 
-```
+```bash
 composer require eppo/php-sdk
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,7 +152,24 @@ async function createConfig () {
         copyright: `Copyright © ${new Date().getFullYear()} Eppo, Inc.`
       },
       prism: {
-        additionalLanguages: ['java', 'groovy', 'ruby'],
+        additionalLanguages: [
+          'bash',
+          'csharp',
+          'go',
+          'groovy',
+          'java',
+          'javascript',
+          'json',
+          'php',
+          'python',
+          'ruby',
+          'rust',
+          'sql',
+          'swift',
+          'tsx',
+          'typescript',
+          'yaml',
+        ],
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme
       },


### PR DESCRIPTION
Looked through the languages used and added them to the list of additional languages.

Some were already covered by default Docusaurus configuration but I decided to be explicit and add all used languages (in case default configuration changes in the future).