### PR TITLE
Add tip on choosing between COUNT DISTINCT and COUNT

### DIFF
--- a/docs/data-management/metrics/simple-metric.md
+++ b/docs/data-management/metrics/simple-metric.md
@@ -138,8 +138,8 @@ Examples: number of unique videos watched per user (if the same video is watched
 Count Distinct is a more expensive operation than Count, especially when there are many unique values in the fact column. **You should only use Count Distinct when it is crucial for the definition of your metric to ignore repeated values.** When repeated values are naturally rare, a Count metric will give similar results to a Count Distinct metric and will incur lower warehouse costs.
 
 For example, consider a podcast app with a fact that logs **podcast listen events**, each with an episode id and a show id. We are interested in two types of outcomes:
-* _Unique shows listened per user_ – an increase in this metric is good news about diversity of content consumed. `Count Distinct` on the show id is needed to measure this correctly. `Count` would not be an adeguate replacement, because it would also increase when users listen to more episodes from the same set of shows.
-* _Episodes listened per user_ – an increase in this metric is good news about overall usage of the app. This can be captured correctly with a `Count` metric. Since repeated listens to the same episode are rare, using `Count Distinct` on episode id would give similar results but incur higher warehouse costs.
+* _Unique shows listened per user_, to measure diversity of content consumption. `Count Distinct` on the show id is needed to capture this correctly. `Count` would not be an adeguate replacement, because it would also increase when users listen to more episodes from shows they already listen to.
+* _Episodes listened per user_, to measure overall content consumption. This can be captured correctly with a `Count` metric. Since repeated listens to the same episode are rare, using `Count Distinct` on episode id would give similar results but incur higher warehouse costs.
 :::
 
 #### Retention

--- a/docs/data-management/metrics/simple-metric.md
+++ b/docs/data-management/metrics/simple-metric.md
@@ -134,6 +134,14 @@ group by 1
 
 Examples: number of unique videos watched per user (if the same video is watched twice, it only counts once), number of unique articles viewed per visitor, number of unique items ordered (if an item is ordered multiple times, it only counts once).
 
+:::tip
+Count Distinct is a more expensive operation than Count, especially when there are many unique values in the fact column. **You should only use Count Distinct when it is crucial for the definition of your metric to ignore repeated values.** When repeated values are naturally rare, a Count metric will give similar results to a Count Distinct metric and will incur lower warehouse costs.
+
+For example, consider a podcast app with a fact that logs **podcast listen events**, each with an episode id and a show id. We are interested in two types of outcomes:
+* _Unique shows listened per user_ – an increase in this metric is good news about diversity of content consumed. `Count Distinct` on the show id is needed to measure this correctly. `Count` would not be an adeguate replacement, because it would also increase when users listen to more episodes from the same set of shows.
+* _Episodes listened per user_ – an increase in this metric is good news about overall usage of the app. This can be captured correctly with a `Count` metric. Since repeated listens to the same episode are rare, using `Count Distinct` on episode id would give similar results but incur higher warehouse costs.
+:::
+
 #### Retention
 
 Retention metrics measure the proportion of entities with at least one event after a fixed number of days (X) from experiment assignment. For example, a 7-day retention metric on website visits would measure the proportion of users who visit the website at least 7 days after being assigned to the experiment.


### PR DESCRIPTION
We noticed that many users are choosing COUNT DISTINCT when COUNT would give similar results. This PR adds an info box about the higher warehouse costs and gives a more fleshed out example on how to choose between the two.