### PR TITLE
Add tip on disabling unused variants + reference for Bayesian

### DIFF
--- a/docs/statistics/multiple-testing.md
+++ b/docs/statistics/multiple-testing.md
@@ -5,6 +5,10 @@ Thus for an experiment with 20 confidence intervals (one variant with 20 metrics
 
 We can avoid this by making our confidence intervals more conservative (wider) in order to control the [Family-wise error rate](https://en.wikipedia.org/wiki/Family-wise_error_rate) (FWER), that is, the probability that any single confidence interval does not cover its underlying true parameter. Naturally, the more confidence intervals we look at, the more stringent this approach is.
 
+:::tip
+Eppo's approach corrects for multiple testing across both **metrics _and_ variants**. If your experiment includes unused variants, disable them by unchecking "Include in this experiment" in the experiment configuration page. This way, the unused variants will not affect the multiple testing correction.
+:::
+
 We allow for control of FWER using the **preferential Bonferroni** method. This is similar to the well-known [Bonferroni correction](https://en.wikipedia.org/wiki/Bonferroni_correction) except that it gives additional weight to the primary metric:
 
 ![Multiple testing settings](/img/planning-experiments/multiple-testing-settings.png)
@@ -12,4 +16,6 @@ We allow for control of FWER using the **preferential Bonferroni** method. This 
 To be precise, if $\gamma$ indicates the weighted alpha spending, and assume we have $k$ treatment variants and $m$ metrics, then the preferential Bonferroni method gives us $\gamma \frac{\alpha}{k}$-confidence intervals for the primary metrics ands $(1-\gamma)\frac{\alpha}{k (m-1)}$-confidence intervals for all other metrics.
 The benefit of this approach over the classical Bonferroni correction is that the power to detect changes in the primary metric does not depend on how many other metrics are added to the experiment.
 
-Note, this setting is unavailable for the Bayesian methodology.
+:::note
+This setting is unavailable for [Bayesian analysis](/statistics/confidence-intervals/analysis-methods/#bayesian-analysis). As long as the prior is specified appropriately, Bayesian approaches do not suffer from the multiple testing problem: see [Gelman et al, _Why we (usually) don't have to worry about multiple comparisons_](https://arxiv.org/abs/0907.2478).
+:::


### PR DESCRIPTION
- Make it more explicit that we do multiple testing correction also across _variants_, and add tip on disabling unused variants
- Add details and reference on why Bayesian does not have MTC