### PR TITLE
chore(ruby): Add `Gemfile` instructions for using SDK

### DIFF
--- a/docs/sdks/server-sdks/ruby.md
+++ b/docs/sdks/server-sdks/ruby.md
@@ -16,6 +16,12 @@ Install the SDK with gem:
 gem install eppo-server-sdk
 ```
 
+or add to you `Gemfile`:
+
+```
+gem 'eppo-server-sdk, '~> 0.3.0'
+```
+
 ## 2. Initialize the SDK
 
 Initialize the SDK with a SDK key, which can be generated in the Eppo interface. Initialization the SDK when your application starts up to generate a singleton client instance, once per application lifecycle:


### PR DESCRIPTION
Bundler with Gemfile is the most common way to consume gems in the ruby world