### PR TITLE
RunLLM Widget Configuration Update

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -71,12 +71,11 @@ async function createConfig () {
       {
         id: "runllm-widget-script",
         type: "module",
-        src: "https://cdn.jsdelivr.net/npm/@runllm/search-widget@stable/dist/run-llm-search-widget.es.js",
+        src: "https://widget.runllm.com",
         "runllm-server-address": "https://api.runllm.com",
         "runllm-assistant-id": "112",
         "runllm-position": "BOTTOM_RIGHT",
         "runllm-keyboard-shortcut": "Mod+j",
-        version: "stable",
         "runllm-preset": "docusaurus",
         "runllm-name": "Eppo",
         "runllm-theme-color": "#6C55D4",


### PR DESCRIPTION
This PR updates the RunLLM widget configuration to use our new widget.runllm.com domain. 

This enables us to have better control over caching and ensures that you are always getting the latest version of our widget. 
We've also updated the version tag so that it's no longer required, so you can omit the version parameter here.

Let me know if you have any questions here, happy to help.

Our docs here have been updated to reflect these changes:
https://docs.runllm.com/chat-widget