### PR TITLE
Android SDK installation instructions point to 3.+

### DIFF
--- a/docs/sdks/client-sdks/android.md
+++ b/docs/sdks/client-sdks/android.md
@@ -13,7 +13,7 @@ Eppo's open source Android SDK can be used for both feature flagging and experim
 You can install the SDK using Gradle by adding to your `build.gradle` file:
 
 ```groovy
-implementation 'cloud.eppo:android-sdk:3.2.0'
+implementation 'cloud.eppo:android-sdk:3.+'
 ```
 
 ## 2. Initialize the SDK


### PR DESCRIPTION
Instead of specific version. All changes on `3.x.x` will be non-breaking.