### PR TITLE
add fastpass troubleshooting

### DIFF
--- a/docs/administration/okta.md
+++ b/docs/administration/okta.md
@@ -33,6 +33,14 @@ Part 2: Securely send over your new app’s information to the Eppo team.
 5. Click **Create a secret link**.
 6. Once the link has been created, share the link along with the pass code to your Eppo team over Slack or email. The Eppo team will complete the configuration our end and let you know your integration is ready.
 
+### Troubleshooting
+
+If Okta logins aren't working, you may have to enable [FastPass](https://help.okta.com/oie/en-us/content/topics/identity-engine/devices/fp/fp-main.htm):
+- On the app configuration page
+- go to SSO > User Authentication
+- click on `view policy details`
+- make sure FastPass is enabled
+
 :::info
 We currently do not support identity provider-initiated logins. Users must navigate to `https://eppo.cloud` to kick off the login process.
 :::


### PR DESCRIPTION
From Matthew at Reverb:
> the auth0 <> okta connections creates a fake collision
> so there's a security policy area you have to configure just for eppo
> you may want to add this to your instructions FYI


> Instructions you can add to the bottom:
> In the app configuration page, go to SSO > Check User Authentication and view policy details.
> Make sure Fast Pass is enabled for Eppo

![Screenshot 2024-08-30 at 4 06 52 PM](https://github.com/user-attachments/assets/38a1079a-8f07-4f5e-a0f7-fd0734e28b30)
