### PR TITLE
FF-3150 Documentation for manual configuration control

### DIFF
--- a/docs/sdks/server-sdks/python.md
+++ b/docs/sdks/server-sdks/python.md
@@ -238,7 +238,7 @@ Once you create the configuration object, configure the client like this:
 eppo_client.get_instance().set_configuration(configuration)
 ```
 
-Upon setting the configuration, the client is initialized and will start serving assignments based on the provided configuration. You can update the configuration anytime.
+Upon setting the configuration, the client is initialized and will start serving assignments based on the provided configuration. You can update the configuration anytime and it will be overwritten atomically.
 
 You can also provide an initial configuration during client initialization:
 ```python


### PR DESCRIPTION
https://linear.app/eppo/issue/FF-3150/%5Bpython%5D-allow-python-sdk-to-be-bootstrapped-from-configuration

Implementation: https://github.com/Eppo-exp/python-sdk/pull/70