### PR TITLE
Mention Guardrail feature on the Non inferiority test page

### DIFF
--- a/docs/guides/advanced-experimentation/non-inferiority-tests.md
+++ b/docs/guides/advanced-experimentation/non-inferiority-tests.md
@@ -1,5 +1,9 @@
 # Running Non-inferiority Tests
 
+:::info
+Eppo now support Non-inferiority tests with the [Guardrail cutoffs](data-management/organizing-metrics/guardrails/).
+:::
+
 This How To guide walks you through how to run non-inferiority tests in Eppo. This evaluation allows you to measure that a new treatment is not significantly worse than an existing or standard treatment in terms of effectiveness or safety.
 
 ## Analysis


### PR DESCRIPTION
We probably should mention that we support non-inferiority tests on a page that explains how to do it yourself.

Alternatively, we could remove that page, but I think it’s reasonable to keep it for a bit in the event users have kept links to this page to point them at the page about the feature.