### PR TITLE
Small formating nit on Bandit page.

### DIFF
--- a/docs/sdks/sdk-features/bandits.md
+++ b/docs/sdks/sdk-features/bandits.md
@@ -89,8 +89,7 @@ Therefore, the logger should write to a table with the following columns (they c
 | action_numeric_attributes (JSON)      | Metadata about numeric attributes of the assigned action; Mapping of attribute names to their values     | {"discount": 0.2}           |
 | action_categorical_attributes (JSON)  | Metadata about non-numeric attributes of the assigned action; Mapping of attribute names to their values | {"promoTextColor": "white"} |
 
-> [!TIP]  
-> Assignment attributes must be single-level. Eppo's bandits do not support multiple levels of JSON attributes.
+:::info Assignment attributes must be single-level. Eppo's bandits do not support multiple levels of JSON attributes. :::
 
 We also recommend storing additional information that is provided to the bandit logger that is not directly used for training the bandit, but is useful for transparency and debugging:
 

--- a/docs/sdks/sdk-features/bandits.md
+++ b/docs/sdks/sdk-features/bandits.md
@@ -89,7 +89,8 @@ Therefore, the logger should write to a table with the following columns (they c
 | action_numeric_attributes (JSON)      | Metadata about numeric attributes of the assigned action; Mapping of attribute names to their values     | {"discount": 0.2}           |
 | action_categorical_attributes (JSON)  | Metadata about non-numeric attributes of the assigned action; Mapping of attribute names to their values | {"promoTextColor": "white"} |
 
-:::info Assignment attributes must be single-level. Eppo's bandits do not support multiple levels of JSON attributes. :::
+:::info Assignment attributes must be single-level. Eppo's bandits do not support multiple levels of JSON attributes.
+:::
 
 We also recommend storing additional information that is provided to the bandit logger that is not directly used for training the bandit, but is useful for transparency and debugging:
 


### PR DESCRIPTION
The `[!TIP]` looked odd on screen.
<img width="264" alt="Screenshot 2024-10-17 at 13 11 05" src="https://github.com/user-attachments/assets/7c078f1f-9892-4a3e-b4d5-41b13ce4c0c6">
