### PR TITLE
Proposal for consistent code snippets on feature flags landing page.

### DIFF
--- a/misc/code_snippets.md
+++ b/misc/code_snippets.md
@@ -8,7 +8,7 @@ import * as EppoSdk from "@eppo/js-client-sdk";
 const variation = EppoSdk.getInstance().getStringAssignment(
   "my-feature-flag",
   user.id,
-  {"country": user.country},
+  { country: user.country },
   "flag-default-value"
 );
 ```
@@ -20,7 +20,7 @@ import * as EppoSdk from "@eppo/node-server-sdk";
 const variation = EppoSdk.getInstance().getStringAssignment(
   "my-feature-flag",
   user.id,
-  {"country": user.country},
+  { country: user.country },
   "flag-default-value"
 );
 ```

--- a/misc/code_snippets.md
+++ b/misc/code_snippets.md
@@ -29,7 +29,7 @@ const variation = EppoSdk.getInstance().getStringAssignment(
 ```python
 import eppo_client
 
-variation = eppo_client.get_instance().get_boolean_assignment(
+variation = eppo_client.get_instance().get_string_assignment(
     'my-feature-flag', 
     user.id, 
     { 'country': user.country }, 
@@ -126,15 +126,15 @@ let variation = EppoClient.shared().getStringAssignment(
 )
 ```
 
-## Java
+## JVM (Java)
 ```java
 import com.eppo.sdk.EppoClient;
-import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;  
 
 String variation = EppoClient.getInstance().getStringAssignment(
     "my-feature-flag",
     user.getId(),
-    new Attributes(Collections.singletonMap("country", user.getCountry())),
+    Map.of("country", EppoValue.valueOf(user.getCountry())),
     "flag-default-value"
 );
 ```
@@ -142,12 +142,13 @@ String variation = EppoClient.getInstance().getStringAssignment(
 ## Android (Kotlin)
 ```kotlin
 import cloud.eppo.android.EppoClient
-import cloud.eppo.ufc.dto.SubjectAttributes
+import cloud.eppo.api.Attributes;  
+import cloud.eppo.api.EppoValue;  
 
 val variation = EppoClient.getInstance().getStringAssignment(
     experimentKey = "my-feature-flag",
     subjectId = user.id,
-    subjectAttributes = SubjectAttributes(mapOf("country" to user.country)),
+    subjectAttributes = Attributes(mapOf("country" to EppoValue.valueOf(user.country))),  
     defaultValue = "flag-default-value"
 )
 ```

--- a/misc/code_snippets.md
+++ b/misc/code_snippets.md
@@ -126,14 +126,28 @@ let variation = EppoClient.shared().getStringAssignment(
 )
 ```
 
+## Java
+```java
+import com.eppo.sdk.EppoClient;
+import cloud.eppo.api.Attributes;
+
+String variation = EppoClient.getInstance().getStringAssignment(
+    "my-feature-flag",
+    user.getId(),
+    new Attributes(Collections.singletonMap("country", user.getCountry())),
+    "flag-default-value"
+);
+```
+
 ## Android (Kotlin)
 ```kotlin
 import cloud.eppo.android.EppoClient
+import cloud.eppo.ufc.dto.SubjectAttributes
 
 val variation = EppoClient.getInstance().getStringAssignment(
     experimentKey = "my-feature-flag",
     subjectId = user.id,
-    subjectAttributes = mapOf("country" to user.country),
+    subjectAttributes = SubjectAttributes(mapOf("country" to user.country)),
     defaultValue = "flag-default-value"
 )
 ```

--- a/misc/code_snippets.md
+++ b/misc/code_snippets.md
@@ -1,0 +1,139 @@
+# Eppo SDK Code Snippets
+Code snippets for https://www.geteppo.com/feature-flagging.
+
+## JavaScript
+```javascript
+import * as EppoSdk from "@eppo/js-client-sdk";
+
+const variation = EppoSdk.getInstance().getStringAssignment(
+  "my-feature-flag",
+  user.id,
+  {"country": user.country},
+  "flag-default-value"
+);
+```
+
+## Node.js
+```typescript
+import * as EppoSdk from "@eppo/node-server-sdk";
+
+const variation = EppoSdk.getInstance().getStringAssignment(
+  "my-feature-flag",
+  user.id,
+  {"country": user.country},
+  "flag-default-value"
+);
+```
+
+## Python
+```python
+import eppo_client
+
+variation = eppo_client.get_instance().get_boolean_assignment(
+    'my-feature-flag', 
+    user.id, 
+    { 'country': user.country }, 
+    'flag-default-value'
+)
+```
+
+## .NET
+```csharp
+using Eppo.Sdk;
+
+var variation = EppoClient.GetInstance().GetStringAssignment(
+  "my-feature-flag", 
+  user.Id, 
+  new Dictionary<string, string> { { "country", user.Country } }, 
+  "flag-default-value"
+);
+```
+
+## Go
+```go
+import "github.com/Eppo-exp/golang-sdk/v6/eppoclient"
+
+var eppoClient = &eppoclient.EppoClient{}
+
+variation, err := eppoClient.GetStringAssignment(
+  "my-feature-flag", 
+  user.Id, 
+  map[string]string{"country": user.Country}, 
+  "flag-default-value"
+)
+```
+
+## PHP
+```php
+use Eppo\Client\EppoClient;
+
+$variation = EppoClient::getInstance()->getStringAssignment(
+  'my-feature-flag', 
+  $user->id, 
+  ['country' => $user->country], 
+  'flag-default-value'
+);
+```
+
+## Rust
+```rust
+use eppo::ClientConfig;
+
+let mut client = ClientConfig::from_api_key("api-key").to_client();
+
+let variation = client.get_string_assignment(
+        "my-feature-flag",
+        &user.id,
+        &[("country", &user.country)].into_iter().collect(),
+        "flag-default-value",
+    )
+    .unwrap_or("flag-default-value".to_string());
+```
+
+## Ruby
+```ruby
+require 'eppo_client'
+
+variation = EppoClient::Client.instance.get_string_assignment(
+  'my-feature-flag',
+  user.id,
+  { country: user.country },
+  'flag-default-value'
+)
+```
+
+## React Native
+```javascript
+import * as EppoSdk from "@eppo/react-native-sdk";
+
+const variation = EppoSDK.getInstance().getStringAssignment(
+  'my-feature-flag',
+  user.id,
+  { country: user.country },
+  'flag-default-value'
+);
+```
+
+## iOS (Swift)
+```swift
+import EppoSDK
+
+let variation = EppoClient.shared().getStringAssignment(
+    experimentKey: "my-feature-flag",
+    subjectId: user.id,
+    subjectAttributes: ["country": user.country],
+    defaultValue: "flag-default-value"
+)
+```
+
+## Android (Kotlin)
+```kotlin
+import cloud.eppo.android.EppoClient
+
+val variation = EppoClient.getInstance().getStringAssignment(
+    experimentKey = "my-feature-flag",
+    subjectId = user.id,
+    subjectAttributes = mapOf("country" to user.country),
+    defaultValue = "flag-default-value"
+)
+```

--- a/misc/code_snippets.md
+++ b/misc/code_snippets.md
@@ -97,7 +97,7 @@ require 'eppo_client'
 variation = EppoClient::Client.instance.get_string_assignment(
   'my-feature-flag',
   user.id,
-  { country: user.country },
+  { 'country' => user.country },
   'flag-default-value'
 )
 ```


### PR DESCRIPTION
Hang asked for feedback on the new Feature Flags landing page ([slack thread](https://eppo-group.slack.com/archives/C07PHSG19A4/p1729720909264639)).

Currently our code snippets are sorta all over the place. I typed up some examples using ai, docs, and git repos, with the intention of having "the same call" for every SDK. I feel this gives a better developer experience when previewing the different languages.

Use the rich diff to see the actual Markdown.