### PR TITLE
Adding init flag availability info to SDKs

### DIFF
--- a/docs/sdks/client-sdks/android.md
+++ b/docs/sdks/client-sdks/android.md
@@ -34,6 +34,8 @@ CompletableFuture<EppoClient> eppoClientFuture = new EppoClient.Builder("YOUR_SD
     .buildAndInitAsync();
 ``` 
 
+Flags and other features become available to the SDK after initialization. 
+
 During initialization, the SDK sends an API request to a CDN to retrieve the most recent experiment configurations from Eppo, 
 such as variation values and traffic allocation. The SDK stores these configurations in memory so that assignments are effectively instant. 
 For more information, see the [architecture overview](/sdks/architecture/overview) page. 

--- a/docs/sdks/client-sdks/ios.md
+++ b/docs/sdks/client-sdks/ios.md
@@ -40,6 +40,8 @@ let assignment = try eppoClient.getStringAssignment(
 );
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 During initialization, the SDK sends an API request to Eppo to retrieve the most recent experiment configurations: variation values, traffic allocation, etc. The SDK stores these configurations in memory, meaning assignments are effectively instant (accordingly, assignment is a synchronous operation). For more information, see the [architecture overview](/sdks/architecture/overview) page.
 
 Eppo's SDK also supports providing the configuration directly at initialization. For more information, see the [initialization modes](#initialization-modes) section below.

--- a/docs/sdks/client-sdks/ios.md
+++ b/docs/sdks/client-sdks/ios.md
@@ -27,7 +27,9 @@ Task {
 }
 ```
 
-(It is recommended to wrap initialization in a `Task` block in order to perform network request asynchronously)
+:::tip
+Wrap initialization in a `Task` block in order to perform network request asynchronously.
+:::
 
 #### Assign anywhere
 

--- a/docs/sdks/client-sdks/javascript.md
+++ b/docs/sdks/client-sdks/javascript.md
@@ -79,6 +79,8 @@ const variation = eppoClient.getBooleanAssignment('show-new-feature', user.id, {
 }, false);
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 During initialization, the SDK sends an API request to Eppo to retrieve the most recent experiment configurations (variation values, traffic allocation, etc.). The SDK stores these configurations in memory so that assignments are effectively instant. For more information, see the [architecture overview](/sdks/architecture/overview) page.
 
 You can customize initialization and polling preferences by passing in additional [initialization options](#initialization-options).

--- a/docs/sdks/client-sdks/react-native.md
+++ b/docs/sdks/client-sdks/react-native.md
@@ -60,6 +60,8 @@ const variation = eppoClient.getBooleanAssignment('show-new-feature', user.id, {
 }, false);
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 After initialization, the SDK begins polling Eppo’s API at regular intervals to retrieve the most recent experiment configurations (variation values, traffic allocation, etc.). You can customize initialization and polling preferences by passing in additional [initialization options](#initialization-options).
 
 The SDK stores these configurations in memory so that assignments thereafter are effectively instant. For more information, see the [architecture overview](/sdks/architecture/overview) page.

--- a/docs/sdks/faqs/common-issues.md
+++ b/docs/sdks/faqs/common-issues.md
@@ -70,16 +70,24 @@ Now, simply add allocation logic specifying to target users with `beta_user = 't
 This does require you to determine whether a user is in the beta group before calling `get<Type>Assignment`, but it helps to keep the Eppo SDK very light.
 
 
+## Wait for SDK Initialization
 
+Eppo's SDK initialization is non-blocking by default. This means your application can continue running while the SDK initializes in the background. However, if you call `get<Type>Assignment` before initialization completes, you may get unexpected results due to race conditions.
 
+### What Happens If You Don't Wait
+When you call `get<Type>Assignment` before initialization completes, one of two things will happen:
 
+1. If the SDK has a cached configuration in persistent storage (like localStorage in JavaScript):
+   - It will use the previous configuration
+   - This might not include your latest changes
 
-## Consider how to best handle non-blocking initialization
+2. If there's no cached configuration:
+   - The SDK will return your specified default value
+   - Your feature flags won't work as expected
 
-Most initialization methods in Eppo’s SDKs are non-blocking in order to minimize their footprint on the applications in which they are run. One consequence of this, however, is that it is possible to invoke the `get<Type>Assignment` method before the SDK has finished initializing. If `get<Type>Assignment` is invoked before the SDK has finished initializing, the SDK may not have access to the most recent configurations. There are two possible outcomes when `get<Type>Assignment` is invoked before the SDK has finished initializing:
+### Best Practice
+Take advantage of your programming language's tools for waiting for asynchronous operations to complete. For example, the `await` keyword in JavaScript can be used to wait for an async operation to complete.
 
-1. If the SDK downloads configurations to a persistent store, e.g. the JavaScript client SDK uses local storage, and a configuration was previously downloaded, then the SDK will assign a variation based on a previously downloaded configuration.
-
-2. If no configurations were previously downloaded or the SDK stores the configuration in memory and loses it during re-initialization, then the SDK will return the default value when `get<Type>Assignment` is invoked.
-
-Most SDKs have an option to `waitForInitialization`, as well as flexible initialization options that you can pass in at initialization.
+:::tip
+Check your specific SDK's documentation for initialization options and best practices for your programming language.
+:::

--- a/docs/sdks/server-sdks/go.md
+++ b/docs/sdks/server-sdks/go.md
@@ -49,6 +49,7 @@ func main() {
 }
 ```
 
+Flags and other features become available to the SDK after initialization. 
 After initialization, the SDK begins polling Eppo's API at regular intervals to retrieve the most recent experiment configurations such as variation values and traffic allocation. The SDK stores these configurations in memory so that assignments thereafter are effectively instant. For more information, see the [architecture overview](/sdks/architecture/overview) page.
 
 ### Waiting for initialization

--- a/docs/sdks/server-sdks/java.md
+++ b/docs/sdks/server-sdks/java.md
@@ -46,6 +46,8 @@ EppoClient.Builder()
   .buildAndInit();
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 Initialization should happen when your application starts up, and generates a singleton client instance to be used 
 throughout the application lifecycle. After initialization, you can access the client with `EppoClient.getInstance()`.
 

--- a/docs/sdks/server-sdks/node.md
+++ b/docs/sdks/server-sdks/node.md
@@ -63,6 +63,8 @@ const variation = eppoClient.getStringAssignment(
 );
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 After initialization, the SDK begins polling Eppo’s API at regular intervals to retrieve the most recent experiment configurations (variation values, traffic allocation, etc.). You can customize initialization and polling preferences by passing in additional [initialization options](#initialization-options).
 
 The SDK stores these configurations in memory so that assignments thereafter are effectively instant. For more information, see the [architecture overview](/sdks/architecture/overview) page.

--- a/docs/sdks/server-sdks/php.md
+++ b/docs/sdks/server-sdks/php.md
@@ -33,6 +33,8 @@ $eppoClient = EppoClient::init(
 );
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 To make the experience of using the library faster, there is an option to start a background polling for randomization params.
 This way background job will start calling the Eppo API, updating the config in the cache.
 

--- a/docs/sdks/server-sdks/ruby.md
+++ b/docs/sdks/server-sdks/ruby.md
@@ -53,6 +53,8 @@ variation = client.get_string_assignment(
 )
 ```
 
+Flags and other features become available to the SDK after initialization. 
+
 After initialization, the SDK begins polling Eppo’s CDN every 30 seconds to retrieve the most recent experiment configurations (variation values, traffic allocation, etc.). Note that polling happens independently of assignment calls and is non blocking.
 
 The SDK stores these configurations in memory so that assignments thereafter are effectively instant. For more information, see the [architecture overview](/sdks/architecture/overview) page.

--- a/docs/sdks/server-sdks/rust.md
+++ b/docs/sdks/server-sdks/rust.md
@@ -32,6 +32,8 @@ client.start_poller_thread();
 
 This creates a client instance that can be reused throughout the application lifecycle, and starts a poller thread to periodically fetch latest feature flag configuration from Eppo server.
 
+Flags and other features become available to the SDK after initialization. 
+
 #### Assign variations
 
 Assign users to flags or experiments using the appropriate `get_*_assignment` function, depending on the type of the flag. For example, to get a string value from a flag, use `get_string_assignment`:


### PR DESCRIPTION
Per gap identified by @chasdevs.

Adding explicit information around when flags become available relative to initialization.