### PR TITLE
Adding API Option Reference Component

### DIFF
--- a/src/components/ApiOptionRef.js
+++ b/src/components/ApiOptionRef.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import MDXContent from '@theme/MDXContent';
+
+function ApiOptionRef({ name, children, defaultValue }) {
+  return (
+    <div className="api-option">
+      <div className="api-option__header">
+        <code className="api-option__name">{name}</code>
+        {defaultValue && (
+          <span className="api-option__default">
+            Default: <code>{defaultValue}</code>
+          </span>
+        )}
+      </div>
+      
+      <div className="api-option__description">
+        <MDXContent>{children}</MDXContent>
+      </div>
+    </div>
+  );
+}
+
+export default ApiOptionRef;

--- a/src/components/ApiOptionRef.js
+++ b/src/components/ApiOptionRef.js
@@ -1,11 +1,31 @@
 import React from 'react';
 import MDXContent from '@theme/MDXContent';
 
+<<<<<<< Updated upstream
 function ApiOptionRef({ name, children, defaultValue }) {
+=======
+function ApiOptionRef({ name, children, defaultValue, type, typeUrl }) {
+>>>>>>> Stashed changes
   return (
     <div className="api-option">
       <div className="api-option__header">
         <code className="api-option__name">{name}</code>
+<<<<<<< Updated upstream
+=======
+        
+        {type && (
+          <span className="api-option__type">
+            {typeUrl ? (
+              <a href={typeUrl} target="_blank" rel="noopener noreferrer">
+                {type}
+              </a>
+            ) : (
+              type
+            )}
+          </span>
+        )}
+
+>>>>>>> Stashed changes
         {defaultValue && (
           <span className="api-option__default">
             Default: <code>{defaultValue}</code>

--- a/src/components/ApiOptionRef.js
+++ b/src/components/ApiOptionRef.js
@@ -1,17 +1,11 @@
 import React from 'react';
 import MDXContent from '@theme/MDXContent';
 
-<<<<<<< Updated upstream
-function ApiOptionRef({ name, children, defaultValue }) {
-=======
 function ApiOptionRef({ name, children, defaultValue, type, typeUrl }) {
->>>>>>> Stashed changes
   return (
     <div className="api-option">
       <div className="api-option__header">
         <code className="api-option__name">{name}</code>
-<<<<<<< Updated upstream
-=======
         
         {type && (
           <span className="api-option__type">
@@ -25,7 +19,6 @@ function ApiOptionRef({ name, children, defaultValue, type, typeUrl }) {
           </span>
         )}
 
->>>>>>> Stashed changes
         {defaultValue && (
           <span className="api-option__default">
             Default: <code>{defaultValue}</code>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -390,3 +390,48 @@ code {
   font-weight: bold;
   color: var(--toc-hover-color)
 }
+
+.api-option {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--ifm-color-gray-300);
+  border-radius: 8px;
+  background-color: var(--card-bg);
+}
+
+.api-option__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.api-option__name {
+  font-size: 1.1rem;
+  color: var(--ifm-color-primary);
+  background: none;
+  padding: 0;
+}
+
+.api-option__default {
+  font-size: 0.9rem;
+  color: var(--ifm-color-gray-600);
+}
+
+.api-option__description {
+  margin: 0;
+}
+
+.api-option__description > div > * {
+  margin-bottom: 1rem;
+}
+
+.api-option__description > div > *:last-child {
+  margin-bottom: 0;
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .api-option {
+  border-color: var(--card-border);
+}
+

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -404,6 +404,7 @@ code {
   align-items: center;
   gap: 1rem;
   margin-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .api-option__name {
@@ -435,3 +436,18 @@ code {
   border-color: var(--card-border);
 }
 
+
+.api-option__type {
+  font-size: 0.9rem;
+  color: var(--ifm-color-gray-600);
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.api-option__type a {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.api-option__type a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## What
Adding a component to template API reference tables.

<img width="804" alt="image" src="https://github.com/user-attachments/assets/c89698de-a48c-4696-9204-67f85ffe1de9">



## Why

Markdown tables leave a lot to be desired for maintainability and authoring. Additionally, the HMTL tables they output have display issues on diminished viewports and also have some issues with inconsistent column sizing.

This component fixes both of those issues. First, the syntax doesn't require putting entire rows into single lines. Second, component lets you pass markdown and react components as part of its inner element for the description. Lastly, it templates out into a responsively designed set of divs.

```markdown
<ApiOptionRef name="Markup Test" defaultValue="5000">
Markdown syntax test

Lorem Ipsum

*italics*

**bold**

[link](https://www.google.com)


Table:

| Header 1 | Header 2 | Header 3 |
| -------- | -------- | -------- |
| Cell 1   | Cell 2   | Cell 3   |

\`\`\`js
// code block
\`\`\`

:::tip
Even other mdx elements work
:::

</ApiOptionRef>


```

Outputs: 

<img width="811" alt="image" src="https://github.com/user-attachments/assets/dac156f6-3801-4068-955a-10771fae1012">

Diminished Viewport:

<img width="471" alt="image" src="https://github.com/user-attachments/assets/71b4913b-1a7d-44b9-949d-33e164b84f45">



