### PR TITLE
Adding Python docs to new template update

### DIFF
--- a/docs/data-management/definitions/fact-sql.md
+++ b/docs/data-management/definitions/fact-sql.md
@@ -94,8 +94,8 @@ Partition dates are disabled by default, if you'd like to enable them in your wo
 If you need to reduce the volume of data the data warehouse needs to process, you can incorporate analysis-specific variables into your Fact SQL. When the experiment pipeline runs, it will filter the query to the date range specified in the analysis set up.
 
 Supported variables:
-- {{analysis_start_timestamp}} - The ‘event data from’ date in the ‘Analysis Set Up’,
-- {{analysis_end_timestamp}} - The ‘event end date’ date in the ‘Analysis Set Up’,
+- `{{analysis_start_timestamp}}` - The ‘event data from’ date in the ‘Analysis Set Up’,
+- `{{analysis_end_timestamp}}` - The ‘event end date’ date in the ‘Analysis Set Up’,
 
 #### Example
 

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -131,7 +131,7 @@ The read more about our specific SDKs, check out the SDK-specific docs below:
 
 - [Node](server-sdks/node)
 - [Java](server-sdks/java)
-- [Python](server-sdks/python)
+- [Python](server-sdks/python/intro)
 - [Go](server-sdks/go)
 - [Rust](server-sdks/rust/intro)
 - [Ruby](server-sdks/ruby/intro)

--- a/docs/sdks/server-sdks/index.md
+++ b/docs/sdks/server-sdks/index.md
@@ -13,7 +13,7 @@ Eppo's server-side SDKs may be used to implement flags and run experiments in yo
 ### Language-specific Documentation
 
 - [Node](/sdks/server-sdks/node)
-- [Python](/sdks/server-sdks/python)
+- [Python](/sdks/server-sdks/python/intro)
 - [Java](/sdks/server-sdks/java)
 - [Dot Net](/sdks/server-sdks/dotnet)
 - [Go](/sdks/server-sdks/go)

--- a/docs/sdks/server-sdks/python/_category.json
+++ b/docs/sdks/server-sdks/python/_category.json
@@ -1,3 +1,0 @@
-{
-  "label": "Python"
-}

--- a/docs/sdks/server-sdks/python/_category_.json
+++ b/docs/sdks/server-sdks/python/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Python",
+  "position": 2
+} 

--- a/docs/sdks/server-sdks/python/announcing-python-4-0.md
+++ b/docs/sdks/server-sdks/python/announcing-python-4-0.md
@@ -101,7 +101,7 @@ If you used `sleep` to wait for `EppoClient` initialization before getting assig
 
 ### Configuration API
 
-This release extends [advanced configuration control API](/sdks/server-sdks/python/#c-advanced-configuration-control) introduced in 3.7.0.
+This release extends [advanced configuration control API](/sdks/server-sdks/python/initialization#advanced-configuration) introduced in 3.7.0.
 
 `EppoClient` now exposes `get_configuration()` method that returns currently-active configuration.
 

--- a/docs/sdks/server-sdks/python/announcing-python-4-0.md
+++ b/docs/sdks/server-sdks/python/announcing-python-4-0.md
@@ -1,18 +1,16 @@
-# Announcing Python SDK 4.0
+---
+title: Differences between Python SDK 3.x and 4.x
+sidebar_position: 10
+---
 
-We’re excited to announce the release of Python SDK 4.0!
+The Python SDK 4.0 provides significant improvements over previous versions through its rewrite using a shared Eppo core library written in Rust.
 
-This release signifies a big milestone for the Python SDK.
-It’s a complete rewrite of the SDK using a shared Eppo core library written in Rust.
+## Key improvements
 
-Using a shared core library allows us to centralize our efforts and provide better performance, stability, and deliver new features faster.
-
-## Better performance
-
-Thanks to Rust’s natural speed, the assignment evaluation performance improved 2–5x depending on the feature flag configuration.
-You may expect even better performance in the future as we continue to optimize the core library.
-
-Additionally, configuration update now happens in a background thread without ever holding Global Interpreter Lock (GIL), so it runs in parallel with your Python threads without slowing them down.
+- **Better Performance**: Assignment evaluation is 2-5x faster than previous versions
+- **Improved Stability**: The shared core library provides more robust and reliable operation
+- **Background Updates**: Configuration updates run in a separate thread without blocking the Global Interpreter Lock (GIL)
+- **Faster Feature Delivery**: The shared core architecture allows us to roll out new features more quickly across all SDKs
 
 ## New API
 

--- a/docs/sdks/server-sdks/python/assignments.mdx
+++ b/docs/sdks/server-sdks/python/assignments.mdx
@@ -1,0 +1,301 @@
+---
+title: Assignments
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ApiOptionRef from '@site/src/components/ApiOptionRef';
+
+Assignments are the mechanism through which a given [Subject](/sdks/sdk-features/subjects) is assigned to a variation for a feature flag or experiment.
+
+The Eppo SDK supports the following assignment types:
+- String
+- Boolean
+- JSON
+- Integer
+- Numeric
+
+## Assignment Types
+
+### String Assignments
+
+String assignments return a string value that is set as the variation. String flags are the most common type of flags and are useful for both A/B/n tests and advanced targeting use cases.
+
+```python
+import eppo_client
+
+client = eppo_client.get_instance()
+
+flag_key = "flag-key-123"
+subject_key = get_user_id() or "user-123"
+default_value = "version-a"
+subject_attributes = {
+    "country": "US",
+    "age": 30,
+    "is_returning_user": True
+}
+
+variant = client.get_string_assignment(
+    flag_key,
+    subject_key,
+    subject_attributes,
+    default_value
+)
+
+# Use the variant value to determine which component to render
+if variant == "version-a":
+    handle_version_a()
+elif variant == "version-b":
+    handle_version_b()
+```
+
+### Boolean Assignments
+
+Boolean flags support simple on/off toggles. They're useful for simple, binary feature switches like blue/green deployments or enabling/disabling a new feature.
+
+```python
+variant = client.get_boolean_assignment(
+    flag_key,
+    subject_key,
+    subject_attributes,
+    False  # default value
+)
+
+if variant:
+    handle_feature_enabled()
+else:
+    handle_feature_disabled()
+```
+
+### JSON Assignments
+
+JSON flags work best for advanced configuration use cases. The JSON flag can include structured information such as:
+- Marketing copy for a promotional campaign
+- Configuration parameters for a feature
+- UI customization settings
+
+```python
+default_campaign = {
+    "hero": False,
+    "hero_image": "placeholder.png",
+    "hero_title": "Placeholder Hero Title",
+    "hero_description": "Placeholder Hero Description"
+}
+
+campaign_json = client.get_json_assignment(
+    flag_key,
+    subject_key,
+    subject_attributes,
+    default_campaign
+)
+
+if campaign_json is not None:
+    campaign.hero = True
+    campaign.hero_image = campaign_json.get("hero_image")
+    campaign.hero_title = campaign_json.get("hero_title", "")
+    campaign.hero_description = campaign_json.get("hero_description", "")
+```
+
+### Numeric Assignments
+
+The SDK provides both integer and floating-point numeric assignments. These are useful for testing different numeric values like:
+- Price points
+- Number of items to display
+- Timeout durations
+
+```python
+# Integer assignment example
+num_items = client.get_integer_assignment(
+    flag_key,
+    subject_key,
+    subject_attributes,
+    10  # default value
+)
+
+# Floating point assignment example
+price = client.get_numeric_assignment(
+    flag_key,
+    subject_key,
+    subject_attributes,
+    9.99  # default value
+)
+```
+
+## Assignment Logging
+
+### Assignment Logger Schema
+
+The SDK will invoke the `log_assignment` function with an `assignment` dictionary that contains the following fields:
+
+<ApiOptionRef 
+  name="timestamp"
+  type="str"
+  defaultValue="undefined"
+>
+
+The time when the subject was assigned to the variation in ISO format. Example: `"2021-06-22T17:35:12.000Z"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="featureFlag"
+  type="str"
+  defaultValue="undefined"
+>
+
+An Eppo feature flag key. Example: `"recommendation-algo"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="allocation"
+  type="str"
+  defaultValue="undefined"
+>
+
+An Eppo allocation key. Example: `"allocation-17"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="experiment"
+  type="str"
+  defaultValue="undefined"
+>
+
+An Eppo experiment key. Example: `"recommendation-algo-allocation-17"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="subject"
+  type="str"
+  defaultValue="undefined"
+>
+
+An identifier of the subject or user assigned to the experiment variation. Example: UUID
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="subjectAttributes"
+  type="Dict[str, Any]"
+  defaultValue="{}"
+>
+
+A free-form map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function. Example: `{ "country": "US" }`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="variation"
+  type="str"
+  defaultValue="undefined"
+>
+
+The experiment variation the subject was assigned to. Example: `"control"`
+</ApiOptionRef>
+
+### Logging to Your Data Warehouse
+
+Eppo's architecture ensures that raw user data never leaves your system. Instead of pushing subject-level exposure events to Eppo's servers, Eppo's SDKs integrate with your existing logging system.
+
+Here are examples of implementing the `AssignmentLogger` class for different logging systems:
+
+<Tabs>
+<TabItem value="console" label="Console">
+
+```python
+from eppo_client.assignment_logger import AssignmentLogger
+
+class ConsoleLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        print(f"Assignment: {assignment}")
+```
+
+</TabItem>
+<TabItem value="segment" label="Segment">
+
+```python
+import analytics
+from eppo_client.assignment_logger import AssignmentLogger
+
+analytics.write_key = '<SEGMENT_WRITE_KEY>'
+
+class SegmentLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        analytics.track(
+            assignment["subject"],
+            "Eppo Randomization Event",
+            assignment
+        )
+```
+
+</TabItem>
+<TabItem value="snowplow" label="Snowplow">
+
+```python
+from snowplow_tracker import Tracker, Emitter
+from eppo_client.assignment_logger import AssignmentLogger
+
+emitter = Emitter("collector.mydomain.net")
+tracker = Tracker(emitters=emitter, namespace="eppo", app_id="eppo-app")
+
+class SnowplowLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        tracker.track_self_describing_event({
+            "schema": "iglu:com.example_company/eppo-event/jsonschema/1-0-2",
+            "data": {
+                "userId": assignment["subject"],
+                "properties": assignment
+            }
+        })
+```
+
+</TabItem>
+</Tabs>
+
+### Deduplicating Logs
+
+To prevent duplicate assignment events, the SDK provides a caching assignment logger with configurable cache behavior:
+
+```python
+import cachetools
+from eppo_client.assignment_logger import AssignmentLogger, AssignmentCacheLogger
+
+class MyLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        # Your logging implementation
+        pass
+
+client_config = Config(
+    api_key="<SDK-KEY>",
+    assignment_logger=AssignmentCacheLogger(
+        MyLogger(),
+        # Cache 1024 least recently used assignments
+        assignment_cache=cachetools.LRUCache(maxsize=1024),
+        # Cache bandit assignments for 10 minutes
+        bandit_cache=cachetools.TTLCache(maxsize=2048, ttl=600)
+    )
+)
+```
+
+## Debugging Assignments
+
+Starting with v4.0.0, the SDK provides detailed assignment information to help debug why a specific variation was chosen:
+
+```python
+evaluation = client.get_boolean_assignment_details(
+    "kill-switch",
+    "test-subject",
+    {"country": "UK", "age": 62},
+    False
+)
+
+print("Assignment:", evaluation.variation)
+print("Details:", evaluation.evaluation_details)
+```
+
+The evaluation details include:
+- Flag and subject information
+- Timestamp and configuration metadata
+- Allocation evaluation results
+- Rule matching details
+- Split calculations
+
+For more information on debugging assignments, see [Debugging Flag Assignments](/sdks/sdk-features/debugging-flag-assignment/). 

--- a/docs/sdks/server-sdks/python/assignments.mdx
+++ b/docs/sdks/server-sdks/python/assignments.mdx
@@ -191,6 +191,8 @@ A free-form map of metadata about the subject. These attributes are only logged 
 The experiment variation the subject was assigned to. Example: `"control"`
 </ApiOptionRef>
 
+<!-- missing: metaData, extraLogging -->
+
 ### Logging to Your Data Warehouse
 
 Eppo's architecture ensures that raw user data never leaves your system. Instead of pushing subject-level exposure events to Eppo's servers, Eppo's SDKs integrate with your existing logging system.
@@ -201,7 +203,7 @@ Here are examples of implementing the `AssignmentLogger` class for different log
 <TabItem value="console" label="Console">
 
 ```python
-from eppo_client.assignment_logger import AssignmentLogger
+from eppo_client import AssignmentLogger
 
 class ConsoleLogger(AssignmentLogger):
     def log_assignment(self, assignment):
@@ -213,7 +215,7 @@ class ConsoleLogger(AssignmentLogger):
 
 ```python
 import analytics
-from eppo_client.assignment_logger import AssignmentLogger
+from eppo_client import AssignmentLogger
 
 analytics.write_key = '<SEGMENT_WRITE_KEY>'
 
@@ -231,7 +233,7 @@ class SegmentLogger(AssignmentLogger):
 
 ```python
 from snowplow_tracker import Tracker, Emitter
-from eppo_client.assignment_logger import AssignmentLogger
+from eppo_client import AssignmentLogger
 
 emitter = Emitter("collector.mydomain.net")
 tracker = Tracker(emitters=emitter, namespace="eppo", app_id="eppo-app")
@@ -256,7 +258,7 @@ To prevent duplicate assignment events, the SDK provides a caching assignment lo
 
 ```python
 import cachetools
-from eppo_client.assignment_logger import AssignmentLogger, AssignmentCacheLogger
+from eppo_client import AssignmentLogger, AssignmentCacheLogger
 
 class MyLogger(AssignmentLogger):
     def log_assignment(self, assignment):

--- a/docs/sdks/server-sdks/python/assignments.mdx
+++ b/docs/sdks/server-sdks/python/assignments.mdx
@@ -191,7 +191,14 @@ A free-form map of metadata about the subject. These attributes are only logged 
 The experiment variation the subject was assigned to. Example: `"control"`
 </ApiOptionRef>
 
-<!-- missing: metaData, extraLogging -->
+<ApiOptionRef 
+  name="metaData"
+  type="Dict[str, Any]"
+  defaultValue="{sdkName: 'python'}"
+>
+
+A free-form map of metadata about the assignment. By default, the SDK will include the SDK name for logging.
+</ApiOptionRef>
 
 ### Logging to Your Data Warehouse
 

--- a/docs/sdks/server-sdks/python/bandits.mdx
+++ b/docs/sdks/server-sdks/python/bandits.mdx
@@ -21,7 +21,7 @@ In order for the bandit to learn an optimized policy, we need to capture and log
 This requires implementing the `log_bandit_action` method in your `AssignmentLogger` class:
 
 ```python
-from eppo_client.assignment_logger import AssignmentLogger
+from eppo_client import AssignmentLogger
 
 class MyLogger(AssignmentLogger):
     def log_assignment(self, assignment):
@@ -142,22 +142,22 @@ To query the bandit for an action, use the `get_bandit_action` function:
 
 ```python
 import eppo_client
-from eppo_client.bandit import Attributes
+from eppo_client import ContextAttributes
 
 client = eppo_client.get_instance()
 bandit_result = client.get_bandit_action(
     "shoe-bandit",  # flag_key
     user.id,        # subject_key
-    Attributes(     # subject_attributes
+    ContextAttributes(     # subject_attributes
         numeric_attributes={"age": 25},
         categorical_attributes={"country": "GB"}
     ),
     {              # actions with their attributes
-        "nike": Attributes(
+        "nike": ContextAttributes(
             numeric_attributes={"brand_affinity": 2.3},
             categorical_attributes={"previously_purchased": True},
         ),
-        "adidas": Attributes(
+        "adidas": ContextAttributes(
             numeric_attributes={"brand_affinity": 0.2},
             categorical_attributes={"previously_purchased": False},
         ),
@@ -176,22 +176,22 @@ else:
 The subject context contains contextual information about the subject that is independent of bandit actions.
 For example, the subject's age or country.
 
-The subject context has type `Attributes` which has two fields:
+The subject context has type `ContextAttributes` which has two fields:
 - `numeric_attributes` (Dict[str, float]): A dictionary of numeric attributes (such as "age")
 - `categorical_attributes` (Dict[str, str]): A dictionary of categorical attributes (such as "country")
 
 :::note
-The `categorical_attributes` are also used for targeting rules for the feature flag similar to how `subject_attributes` are used with regular feature flags.
+The `ContextAttributes` are also used for targeting rules for the feature flag similar to how `subject_attributes` are used with regular feature flags.
 :::
 
 ### Action Contexts
 
-Next, supply a dictionary with actions and their attributes: `actions: Dict[str, Attributes]`.
+Next, supply a dictionary with actions and their attributes: `actions: Dict[str, ContextAttributes]`.
 If the user is assigned to the bandit, the bandit selects one of the actions supplied here.
 All actions supplied are considered to be valid; if an action should not be shown to a user, do not include it in this dictionary.
 
 The action attributes are similar to the `subject_attributes` but hold action-specific information.
-You can use `Attributes.empty()` to create an empty attribute context.
+You can use `ContextAttributes.empty()` to create an empty attribute context.
 
 Note that relevant action contexts are subject-action interactions. For example, there could be a "brand-affinity" model
 that computes brand affinities of users to brands, and scores of that model can be added to the action context to provide

--- a/docs/sdks/server-sdks/python/bandits.mdx
+++ b/docs/sdks/server-sdks/python/bandits.mdx
@@ -1,0 +1,237 @@
+---
+title: Contextual Bandits
+sidebar_position: 5
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ApiOptionRef from '@site/src/components/ApiOptionRef';
+
+Eppo's Python SDK supports contextual multi-armed bandits, which dynamically optimize assignments based on user context. A bandit balances exploration of new actions with exploitation of known successful actions to maximize a specified metric.
+
+## Bandit Setup
+
+To leverage Eppo's contextual bandits using the Python SDK, there are two additional steps over regular feature flags:
+1. Add a bandit action logger to the assignment logger
+2. Query the bandit for an action
+
+### Logging Bandit Actions
+
+In order for the bandit to learn an optimized policy, we need to capture and log the bandit's actions.
+This requires implementing the `log_bandit_action` method in your `AssignmentLogger` class:
+
+```python
+from eppo_client.assignment_logger import AssignmentLogger
+
+class MyLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        # Your assignment logging implementation
+        pass
+
+    def log_bandit_action(self, bandit_action):
+        # Your bandit action logging implementation
+        pass
+```
+
+### Bandit Action Schema
+
+The SDK will invoke the `log_bandit_action` function with a `bandit_action` dictionary containing the following fields:
+
+<ApiOptionRef 
+  name="timestamp"
+  type="str"
+  defaultValue="undefined"
+>
+
+The time when the action is taken in UTC. Example: `"2024-03-22T14:26:55.000Z"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="flagKey"
+  type="str"
+  defaultValue="undefined"
+>
+
+The key of the feature flag corresponding to the bandit. Example: `"bandit-test-allocation-4"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="banditKey"
+  type="str"
+  defaultValue="undefined"
+>
+
+The key (unique identifier) of the bandit. Example: `"ad-bandit-1"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="subject"
+  type="str"
+  defaultValue="undefined"
+>
+
+An identifier of the subject or user assigned to the experiment variation. Example: `"ed6f85019080"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="subjectNumericAttributes"
+  type="Dict[str, float]"
+  defaultValue="{}"
+>
+
+Metadata about numeric attributes of the subject. Example: `{"age": 30}`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="subjectCategoricalAttributes"
+  type="Dict[str, str]"
+  defaultValue="{}"
+>
+
+Metadata about non-numeric attributes of the subject. Example: `{"loyalty_tier": "gold"}`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="action"
+  type="str"
+  defaultValue="undefined"
+>
+
+The action assigned by the bandit. Example: `"promo-20%-off"`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="actionNumericAttributes"
+  type="Dict[str, float]"
+  defaultValue="{}"
+>
+
+Metadata about numeric attributes of the assigned action. Example: `{"brandAffinity": 0.2}`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="actionCategoricalAttributes"
+  type="Dict[str, str]"
+  defaultValue="{}"
+>
+
+Metadata about non-numeric attributes of the assigned action. Example: `{"previouslyPurchased": "false"}`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="actionProbability"
+  type="float"
+  defaultValue="undefined"
+>
+
+The weight between 0 and 1 the bandit valued the assigned action. Example: `0.25`
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="modelVersion"
+  type="str"
+  defaultValue="undefined"
+>
+
+Unique identifier for the version of the bandit parameters used. Example: `"v123"`
+</ApiOptionRef>
+
+## Querying the Bandit
+
+To query the bandit for an action, use the `get_bandit_action` function:
+
+```python
+import eppo_client
+from eppo_client.bandit import Attributes
+
+client = eppo_client.get_instance()
+bandit_result = client.get_bandit_action(
+    "shoe-bandit",  # flag_key
+    user.id,        # subject_key
+    Attributes(     # subject_attributes
+        numeric_attributes={"age": 25},
+        categorical_attributes={"country": "GB"}
+    ),
+    {              # actions with their attributes
+        "nike": Attributes(
+            numeric_attributes={"brand_affinity": 2.3},
+            categorical_attributes={"previously_purchased": True},
+        ),
+        "adidas": Attributes(
+            numeric_attributes={"brand_affinity": 0.2},
+            categorical_attributes={"previously_purchased": False},
+        ),
+    },
+    "control"      # default_value
+)
+
+if bandit_result.action:
+    show_shoe_ad(bandit_result.action)
+else:
+    show_default_ad()
+```
+
+### Subject Context
+
+The subject context contains contextual information about the subject that is independent of bandit actions.
+For example, the subject's age or country.
+
+The subject context has type `Attributes` which has two fields:
+- `numeric_attributes` (Dict[str, float]): A dictionary of numeric attributes (such as "age")
+- `categorical_attributes` (Dict[str, str]): A dictionary of categorical attributes (such as "country")
+
+:::note
+The `categorical_attributes` are also used for targeting rules for the feature flag similar to how `subject_attributes` are used with regular feature flags.
+:::
+
+### Action Contexts
+
+Next, supply a dictionary with actions and their attributes: `actions: Dict[str, Attributes]`.
+If the user is assigned to the bandit, the bandit selects one of the actions supplied here.
+All actions supplied are considered to be valid; if an action should not be shown to a user, do not include it in this dictionary.
+
+The action attributes are similar to the `subject_attributes` but hold action-specific information.
+You can use `Attributes.empty()` to create an empty attribute context.
+
+Note that relevant action contexts are subject-action interactions. For example, there could be a "brand-affinity" model
+that computes brand affinities of users to brands, and scores of that model can be added to the action context to provide
+additional context for the bandit.
+
+### Result
+
+The `bandit_result` is an instance of `EvaluationResult`, which has two fields:
+- `variation` (str): The variation that was assigned to the subject
+- `action` (Optional[str]): The action that was assigned to the subject
+
+The variation returns the feature flag variation, this can be the bandit itself, or the "status quo" variation if the user is not assigned to the bandit.
+If we are unable to generate a variation, for example when the flag is turned off, then the `default` variation is returned.
+In both of those cases, the `action` is `None`, and you should use the status-quo algorithm to select an action.
+
+When `action` is not `None`, the bandit has selected that action to be shown to the user.
+
+### Status Quo Algorithm
+
+In order to accurately measure the performance of the bandit, we need to compare it to the status quo algorithm using an experiment.
+This status quo algorithm could be a complicated algorithm that selects an action according to a different model, or a simple baseline such as selecting a fixed or random action.
+
+When you create an analysis allocation for the bandit and the `action` in `EvaluationResult` is `None`, implement the desired status quo algorithm based on the `variation` value.
+
+## Debugging
+
+You may encounter a situation where a bandit assignment produces a value that you did not expect. The SDK provides detailed evaluation information through the `get_bandit_action_details()` method:
+
+```python
+evaluation = client.get_bandit_action_details(
+    "shoe-bandit",
+    "test-subject",
+    subject_attributes,
+    actions,
+    "control"
+)
+
+print("Assignment:", evaluation.variation)
+print("Action:", evaluation.action)
+print("Details:", evaluation.evaluation_details)
+```
+
+For more information on debugging assignments, see [Debugging Flag Assignment](/sdks/sdk-features/debugging-flag-assignment/). 

--- a/docs/sdks/server-sdks/python/examples.mdx
+++ b/docs/sdks/server-sdks/python/examples.mdx
@@ -1,0 +1,152 @@
+---
+title: Usage Examples
+sidebar_position: 6
+---
+
+In this section, we will go through a few examples of how to use Eppo's Python SDK in two common situations: batch processing and real-time applications.
+
+## Usage in a batch process
+
+As a basic example, imagine using Eppo's SDK to randomize users in a batch machine learning evaluation script. Further, imagine we're testing an upgrade from model version `v1.0.0` to `v1.1.0`. First we'd create a feature flag called `ml-model-version` with two variations: `v1.0.0` and `v1.1.0`. The Eppo UI should look like something like this:
+
+![Feature flag configuration](/img/feature-flagging/script_example_flag_config.png)
+
+:::note
+If you have not set up an experiment in Eppo's UI before, please see the [experiment quickstart guide](/experiment-allocation-quickstart).
+:::
+
+To keep the example simple, let's not worry about logging assignments to a warehouse and instead just write them to a local file using Python's built-in `logging` package.
+
+Your ML model evaluation script might then look something like this:
+
+```python title=script_example.py
+import logging
+import os
+from uuid import uuid4
+import eppo_client
+from eppo_client.config import Config, AssignmentLogger
+
+logging.basicConfig(
+    filename='eppo_assignments.csv',
+    level=logging.INFO,
+    format=f'%(message)s'
+)
+
+
+class LocalAssignmentLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        logging.info(assignment)
+
+# initialize the Eppo client
+client_config = Config(
+    api_key=os.getenv("EPPO_API_KEY"),
+    assignment_logger=LocalAssignmentLogger()
+)
+eppo_client.init(client_config)
+
+# get an instance and wait for initialization to complete
+client = eppo_client.get_instance()
+client.wait_for_initialization()
+
+for _ in range(10):
+    # create random user ids for demonstration purposes
+    user_id = str(uuid4())
+
+    model_version = client.get_string_assignment(
+        "ml-model-version", 
+        user_id, 
+        {}, 
+        "v1.0.0"
+    )
+
+    # TODO: Evaluate the appropriate model version for the user
+
+    print(f"{user_id}: {model_version}")
+```
+
+Note that since the `get_string_assignment` call is deterministic, the same `user_id` will always produce the same `variation`. That is, if this script runs at a regular cadence, you don't need to worry about users switching between variations.
+
+After running this, you can inspect the logs in the `eppo_assignments.csv` file:
+
+```json title=eppo_assignments.csv
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.1.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': 'f54ba5f3-90bb-4cdf-bf56-ca0335ede92c', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.093538Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': '3ccfcb7c-1b5d-4d3b-8513-198ef97c20d0', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094055Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': '7d4d81be-e7e5-42b5-b096-79b2dd25a0a1', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094164Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.1.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': '71435619-b1e5-446c-aabe-18c28c7a96af', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094246Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': '10ae9617-7e06-459a-a699-a464e6a9dbb9', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094321Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': 'f2f4b2ed-9fdd-4150-af88-27ef17470d45', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094394Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': '169d2066-8861-4230-9fce-809a1bb2a3cc', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094463Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': '359ff058-c8ad-4d35-8559-44c8ad0c235f', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094530Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.0.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': 'b13ac779-e639-4367-8afb-7942f789ec12', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094595Z'}
+{'base': {'featureFlag': 'ml-model-version', 'allocation': 'allocation-10061', 'experiment': 'ml-model-version-allocation-10061', 'variation': 'v1.1.0', 'metaData': {'sdkName': 'python', 'sdkVersion': '4.0.1', 'coreVersion': '4.0.0'}}, 'subject': 'a0bc2b98-bfc2-4740-a3e0-18151ca88dcd', 'subjectAttributes': {}, 'timestamp': '2024-10-11T03:24:12.094660Z'}
+```
+
+In a real-world scenario, you would send these logs to your warehouse of choice. From there, you would create an [Assignment SQL Definition](/data-management/definitions/assignment-sql/) and analyze your experiment like any other experiment in Eppo. For more information on analyzing experiments, see our [Experiment Analysis Quickstart](/experiment-quickstart/).
+
+## Targeting users in Django
+
+While Eppo's SDK can be used for batch processing as described above, it is most commonly used in live applications to perform assignment in real time.
+
+Let’s say you are running a Django service with the User-Agent package. You can use feature flags to offer a payment method that adapts to the browser (only Safari users should be offered to use Apple Pay), the country (Dutch users can use iDEAL), and loyalty status (members might use their points). You can use a feature flag to configure what is possible in which country, for which users, etc.
+
+To make the decision, you can put the relevant information (`country`, `loyalty_tier`, `device_type`, etc.) in a `session_attributes` dictionary:
+
+```python
+# ...
+from ipware import get_client_ip
+from django.contrib.gis.utils import GeoIP2
+g = GeoIP2()
+
+# ...
+
+if request.method == 'POST':
+    ip, is_routable = get_client_ip(request)
+    if is_routable:
+        country_code = g.city(ip)["country_code"]
+    else:
+        country_code = "UNKNOWN"
+
+    session_attributes = {
+        'country_code': country_code,
+        'loyalty_tier': request.session.loyalty_tier,
+        'browser_type': request.user_agent.browser.family,
+        'device_type': request.user_agent.device.family,
+    }
+
+    payment_method = client.get_string_assignment(
+        "payment-method", 
+        request.user.id, 
+        session_attributes,
+        "default_checkout"
+    )
+
+    if variation == 'apple_pay':
+        # TODO: Offer Apple Pay
+    elif variation == 'ideal':
+        # TODO: Offer iDEAL
+    else:
+        # TODO: Offer default checkout
+
+```
+
+
+:::note
+
+The `MATCHES`, `ONE_OF`, and `NOT_ONE_OF` operators are evaluated on string representations of the subject attributes. To be consistent with other SDKs, note that conversion of subject attributes from floats, booleans, and None is different from the standard Python conversion.
+
+In particular, `True` and `False` are converted to the string values `"true"` and `"false`". Integer floats are converted to integers before converting to a string. That is, `10.0` becomes `"10"`, whereas `10.1` becomes `"10.1"`. Finally, `None` is converted to the string `null`.
+
+:::
+
+Then, in the Eppo UI, your experiment assignment should look something like this:
+
+![Experiment allocation configuration](/img/feature-flagging/django_example_allocation_config.png)
+
+These rules are evaluated from top to bottom. That is, in this example an iOS user in the Netherlands will be put into the first category and see iDEAL, but not Apple Pay. If you instead want to offer such users both options, consider implementing two flags: one for iDEAL, one for Apple Pay.
+
+Our approach is highly flexible: it lets you configure properties that match the relevant entity for your feature flag or experiment. For example, if a user is usually on iOS but they are connecting from a PC browser this time, they probably should not be offered an Apple Pay option, in spite of being labelled an iOS user.
+
+:::note
+If you create rules based on attributes on a flag or an experiment, those attributes should be passed in on every assignment call.
+:::
+

--- a/docs/sdks/server-sdks/python/initialization.mdx
+++ b/docs/sdks/server-sdks/python/initialization.mdx
@@ -27,6 +27,10 @@ After initialization, you can get an instance of the client using `get_instance(
 client = eppo_client.get_instance()
 ```
 
+:::note
+When using pre-forking web servers (e.g., uWSGI), it's important to initialize Eppo SDK after forking process is complete. See [Using Eppo SDK with pre-forking servers](/sdks/preforking/) for more information.
+:::
+
 ## Advanced Configuration
 
 Basic initialization is great for most use cases, but the SDK provides options that you can use during initialization to customize the behavior of the SDK.

--- a/docs/sdks/server-sdks/python/initialization.mdx
+++ b/docs/sdks/server-sdks/python/initialization.mdx
@@ -13,9 +13,9 @@ To complete basic initialization, you only need to provide an SDK key. [Create a
 
 ```python
 import eppo_client
-from eppo_client import Config
+from eppo_client import ClientConfig
 
-client_config = Config(api_key="<SDK-KEY>")
+client_config = ClientConfig(api_key="<SDK-KEY>")
 eppo_client.init(client_config)
 ```
 
@@ -35,7 +35,7 @@ Basic initialization is great for most use cases, but the SDK provides options t
 
 The `Config` class accepts the following options:
 
-<ApiOptionRef 
+<ApiOptionRef
   name="api_key"
   type="str"
   defaultValue="None"
@@ -44,16 +44,15 @@ The `Config` class accepts the following options:
 Your SDK key from the Eppo dashboard. Required.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="assignment_logger"
   type="AssignmentLogger"
-  defaultValue="None"
 >
 
-A callback that sends each assignment to your data warehouse. Required only for experiment analysis.
+A callback that sends each assignment to your data warehouse. Required.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="poll_interval_seconds"
   type="Optional[int]"
   defaultValue="30"
@@ -62,16 +61,16 @@ A callback that sends each assignment to your data warehouse. Required only for 
 The interval in seconds at which the SDK polls for configuration updates. If set to `None`, polling is disabled.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="poll_jitter_seconds"
   type="int"
-  defaultValue="30"
+  defaultValue="3"
 >
 
 The jitter in seconds to add to the poll interval to prevent thundering herd problems.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="is_graceful_mode"
   type="bool"
   defaultValue="True"
@@ -80,7 +79,7 @@ The jitter in seconds to add to the poll interval to prevent thundering herd pro
 When true, gracefully handles all exceptions within the assignment function and returns the default value.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="initial_configuration"
   type="Optional[Configuration]"
   defaultValue="None"
@@ -92,7 +91,7 @@ If set, the client will use this configuration until it fetches a fresh one.
 For example, to poll for changes every minute with jitter:
 
 ```python
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
     assignment_logger=MyLogger(),
     poll_interval_seconds=60,
@@ -112,11 +111,7 @@ client.wait_for_initialization()  # Blocks until configuration is loaded
 
 This is particularly useful for scripting use cases when subsequent calls to Eppo's client will happen immediately after initialization.
 
-### Configuration Caching
-
-The SDK can cache previously loaded configurations for use in future sessions. This makes the SDK initialize faster and provides resilience against network issues.
-
-#### Advanced Configuration Control
+### Advanced Configuration Control
 
 Starting with `v4.0.0`, the Python SDK exposes an advanced API to allow manual control over configuration:
 
@@ -137,25 +132,15 @@ This API can be used for debugging or advanced optimizations like:
 - Faster client-side initialization from server configuration
 - Debugging flag assignments
 
-### Usage in Serverless Environments
+#### Usage in Serverless Environments
 
-The default periodic polling setup is suitable for most cases but may not be efficient in short-lived serverless environments like AWS Lambda, where a new configuration is fetched on every function call.
+The default periodic polling setup is suitable for most cases but may be inefficient in short-lived serverless environments like AWS Lambda, where a new configuration is fetched on every function call.
 
-For serverless environments, you can:
-
-1. Disable polling:
-```python
-client_config = Config(
-    api_key="<SDK-KEY>",
-    poll_interval_seconds=None  # Disable polling
-)
-```
-
-2. Manually control configuration updates:
+For serverless environments, you can manually control configuration updates:
 ```python
 # Initialize with a cached configuration
 cached_config = get_cached_configuration()  # Your caching logic
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
     poll_interval_seconds=None,
     initial_configuration=cached_config
@@ -163,9 +148,8 @@ client_config = Config(
 eppo_client.init(client_config)
 
 # Later, update configuration manually if needed
-client = eppo_client.get_instance()
 new_config = fetch_new_configuration()  # Your update logic
-client.set_configuration(new_config)
+eppo_client.get_instance().set_configuration(new_config)
 ```
 
 ### Example Configurations
@@ -176,11 +160,11 @@ Here are some common configuration patterns based on different needs:
 If you want to always use the latest flag values:
 
 ```python
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
-    poll_interval_seconds=30,  # Poll frequently
-    poll_jitter_seconds=5,
-    is_graceful_mode=False  # Fail fast if there are issues
+    poll_interval_seconds=10,  # Poll frequently
+    poll_jitter_seconds=1,
+    is_graceful_mode=False  # Throw exceptions if there are issues (useful for debugging)
 )
 ```
 
@@ -189,11 +173,11 @@ If you want to optimize for quick initialization:
 
 ```python
 cached_config = get_cached_configuration()  # Your caching logic
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
     poll_interval_seconds=300,  # Poll less frequently
     initial_configuration=cached_config,
-    is_graceful_mode=True  # Use default values if there are issues
+    is_graceful_mode=True  # Use default values if there are issues (preferred in production)
 )
 ```
 
@@ -202,8 +186,9 @@ For completely offline operation:
 
 ```python
 offline_config = get_offline_configuration()  # Your configuration source
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
     poll_interval_seconds=None,  # Disable polling
     initial_configuration=offline_config
 )
+```

--- a/docs/sdks/server-sdks/python/initialization.mdx
+++ b/docs/sdks/server-sdks/python/initialization.mdx
@@ -1,0 +1,209 @@
+---
+title: Initialization
+sidebar_position: 3
+---
+
+import ApiOptionRef from '@site/src/components/ApiOptionRef';
+
+The Eppo Python SDK is easy to initialize while offering robust customization options, making it adaptable to various use cases such as offline mode, custom caching requirements, and ultra-low-latency initialization.
+
+## Initialize the SDK
+
+To complete basic initialization, you only need to provide an SDK key. [Create an SDK key](/sdks/sdk-keys) if you don't already have one.
+
+```python
+import eppo_client
+from eppo_client import Config
+
+client_config = Config(api_key="<SDK-KEY>")
+eppo_client.init(client_config)
+```
+
+## Use the SDK instance
+
+After initialization, you can get an instance of the client using `get_instance()`:
+
+```python
+client = eppo_client.get_instance()
+```
+
+## Advanced Configuration
+
+Basic initialization is great for most use cases, but the SDK provides options that you can use during initialization to customize the behavior of the SDK.
+
+### Initialization Options
+
+The `Config` class accepts the following options:
+
+<ApiOptionRef 
+  name="api_key"
+  type="str"
+  defaultValue="None"
+>
+
+Your SDK key from the Eppo dashboard. Required.
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="assignment_logger"
+  type="AssignmentLogger"
+  defaultValue="None"
+>
+
+A callback that sends each assignment to your data warehouse. Required only for experiment analysis.
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="poll_interval_seconds"
+  type="Optional[int]"
+  defaultValue="30"
+>
+
+The interval in seconds at which the SDK polls for configuration updates. If set to `None`, polling is disabled.
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="poll_jitter_seconds"
+  type="int"
+  defaultValue="30"
+>
+
+The jitter in seconds to add to the poll interval to prevent thundering herd problems.
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="is_graceful_mode"
+  type="bool"
+  defaultValue="True"
+>
+
+When true, gracefully handles all exceptions within the assignment function and returns the default value.
+</ApiOptionRef>
+
+<ApiOptionRef 
+  name="initial_configuration"
+  type="Optional[Configuration]"
+  defaultValue="None"
+>
+
+If set, the client will use this configuration until it fetches a fresh one.
+</ApiOptionRef>
+
+For example, to poll for changes every minute with jitter:
+
+```python
+client_config = Config(
+    api_key="<SDK-KEY>",
+    assignment_logger=MyLogger(),
+    poll_interval_seconds=60,
+    poll_jitter_seconds=10
+)
+eppo_client.init(client_config)
+```
+
+### Waiting for Configuration
+
+Starting in version `v4.0.0`, the SDK has a method to wait for the configuration to be fetched: `wait_for_initialization()`. This method parks the current Python thread until the client fetches the configuration. It releases Global Interpreter Lock (GIL) while it waits, so it does not block other Python threads.
+
+```python
+client = eppo_client.get_instance()
+client.wait_for_initialization()  # Blocks until configuration is loaded
+```
+
+This is particularly useful for scripting use cases when subsequent calls to Eppo's client will happen immediately after initialization.
+
+### Configuration Caching
+
+The SDK can cache previously loaded configurations for use in future sessions. This makes the SDK initialize faster and provides resilience against network issues.
+
+#### Advanced Configuration Control
+
+Starting with `v4.0.0`, the Python SDK exposes an advanced API to allow manual control over configuration:
+
+```python
+from eppo_client import Configuration
+
+# Get current configuration
+config = client.get_configuration()
+
+# Access specific parts of the configuration
+flags_config = config.get_flags_configuration()
+flag_keys = config.get_flag_keys()
+bandit_keys = config.get_bandit_keys()
+```
+
+This API can be used for debugging or advanced optimizations like:
+- Caching configuration
+- Faster client-side initialization from server configuration
+- Debugging flag assignments
+
+### Usage in Serverless Environments
+
+The default periodic polling setup is suitable for most cases but may not be efficient in short-lived serverless environments like AWS Lambda, where a new configuration is fetched on every function call.
+
+For serverless environments, you can:
+
+1. Disable polling:
+```python
+client_config = Config(
+    api_key="<SDK-KEY>",
+    poll_interval_seconds=None  # Disable polling
+)
+```
+
+2. Manually control configuration updates:
+```python
+# Initialize with a cached configuration
+cached_config = get_cached_configuration()  # Your caching logic
+client_config = Config(
+    api_key="<SDK-KEY>",
+    poll_interval_seconds=None,
+    initial_configuration=cached_config
+)
+eppo_client.init(client_config)
+
+# Later, update configuration manually if needed
+client = eppo_client.get_instance()
+new_config = fetch_new_configuration()  # Your update logic
+client.set_configuration(new_config)
+```
+
+### Example Configurations
+
+Here are some common configuration patterns based on different needs:
+
+#### Prioritize Flag Value Freshness
+If you want to always use the latest flag values:
+
+```python
+client_config = Config(
+    api_key="<SDK-KEY>",
+    poll_interval_seconds=30,  # Poll frequently
+    poll_jitter_seconds=5,
+    is_graceful_mode=False  # Fail fast if there are issues
+)
+```
+
+#### Prioritize Fast Initialization
+If you want to optimize for quick initialization:
+
+```python
+cached_config = get_cached_configuration()  # Your caching logic
+client_config = Config(
+    api_key="<SDK-KEY>",
+    poll_interval_seconds=300,  # Poll less frequently
+    initial_configuration=cached_config,
+    is_graceful_mode=True  # Use default values if there are issues
+)
+```
+
+#### Offline Mode
+For completely offline operation:
+
+```python
+offline_config = get_offline_configuration()  # Your configuration source
+client_config = Config(
+    api_key="<SDK-KEY>",
+    poll_interval_seconds=None,  # Disable polling
+    initial_configuration=offline_config
+)

--- a/docs/sdks/server-sdks/python/intro.mdx
+++ b/docs/sdks/server-sdks/python/intro.mdx
@@ -1,0 +1,29 @@
+---
+title: SDK Guide
+sidebar_position: 1
+---
+import FeatureCard from '/src/components/FeatureCard';
+
+The Eppo Python SDK allows you to manage feature flags and experiments in your Python applications.
+
+<div className="feature-card-container">
+  <FeatureCard 
+    title="SDK Quickstart" 
+    description="Install the SDK and create a basic feature flag"
+    link="/sdks/server-sdks/python/quickstart"
+    iconSrc="/img/what-is-eppo/feature-flag.svg"
+  />
+  <FeatureCard 
+    title="API Reference"
+    description="Reference for all SDK methods."
+    link="https://github.com/Eppo-exp/eppo-multiplatform"
+    iconSrc="/img/sdk-overviews/book-stack.svg"
+  />
+  
+  <FeatureCard 
+    title="Github"
+    description="View the source code on Github."
+    link="https://github.com/Eppo-exp/eppo-multiplatform"
+    iconSrc="/img/sdk-overviews/github-mark.svg"
+  />
+</div> 

--- a/docs/sdks/server-sdks/python/quickstart.mdx
+++ b/docs/sdks/server-sdks/python/quickstart.mdx
@@ -29,9 +29,9 @@ First, initialize the SDK using your SDK key:
 
 ```python
 import eppo_client
-from eppo_client import Config
+from eppo_client import ClientConfig
 
-client_config = Config(api_key="<SDK-KEY>")
+client_config = ClientConfig(api_key="<SDK-KEY>")
 eppo_client.init(client_config)
 ```
 
@@ -85,13 +85,13 @@ While feature flags are useful, they do not send you any information about how y
 To log events through the SDK, you need to implement the `AssignmentLogger` class:
 
 ```python
-from eppo_client.assignment_logger import AssignmentLogger
+from eppo_client import AssignmentLogger
 
 class MyLogger(AssignmentLogger):
     def log_assignment(self, assignment):
         print(f"Logging assignment: {assignment}")  # Replace with your logging logic
 
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
     assignment_logger=MyLogger()
 )
@@ -111,7 +111,7 @@ Contextual Multi-Armed Bandits are a way to dynamically optimize assignments bas
 Setting up a bandit requires implementing both an assignment logger and a bandit logger:
 
 ```python
-from eppo_client.assignment_logger import AssignmentLogger
+from eppo_client import AssignmentLogger
 
 class MyLogger(AssignmentLogger):
     def log_assignment(self, assignment):
@@ -120,7 +120,7 @@ class MyLogger(AssignmentLogger):
     def log_bandit_action(self, bandit_action):
         print(f"Logging bandit action: {bandit_action}")
 
-client_config = Config(
+client_config = ClientConfig(
     api_key="<SDK-KEY>",
     assignment_logger=MyLogger()
 )
@@ -133,22 +133,22 @@ Instead of making simple assignments with a bandit, you query the bandit for act
 
 ```python
 import eppo_client
-from eppo_client.bandit import Attributes
+from eppo_client import ContextAttributes
 
 client = eppo_client.get_instance()
 bandit_result = client.get_bandit_action(
     "shoe-bandit",
     user.id,
-    Attributes(
+    ContextAttributes(
         numeric_attributes={"age": user.age},
         categorical_attributes={"country": user.country}
     ),
     {
-        "nike": Attributes(
+        "nike": ContextAttributes(
             numeric_attributes={"brand_affinity": 2.3},
             categorical_attributes={"previously_purchased": True},
         ),
-        "adidas": Attributes(
+        "adidas": ContextAttributes(
             numeric_attributes={"brand_affinity": 0.2},
             categorical_attributes={"previously_purchased": False},
         ),

--- a/docs/sdks/server-sdks/python/quickstart.mdx
+++ b/docs/sdks/server-sdks/python/quickstart.mdx
@@ -1,0 +1,175 @@
+---
+title: Quickstart
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The Eppo Python SDK enables feature flags and experiments in your Python applications with only a few lines of code.
+
+The SDK handles all the complexity of feature flag evaluation and experiment assignment locally in your application, with no network calls required after initial setup. This guide will walk you through installing the SDK and implementing your first feature flag, experiment, and contextual bandit.
+
+## Installation
+
+First, install the SDK using pip:
+
+```bash
+pip install eppo-server-sdk
+```
+
+## Feature Flags
+Feature flags are a way to toggle features on and off without needing to deploy code.
+
+### Initialize the SDK
+
+[Create an SDK key](/sdks/sdk-keys) if you don't already have one. 
+
+First, initialize the SDK using your SDK key:
+
+```python
+import eppo_client
+from eppo_client import Config
+
+client_config = Config(api_key="<SDK-KEY>")
+eppo_client.init(client_config)
+```
+
+:::note
+The SDK key is different from the project API key. You can find your SDK key in the [SDK Keys section of the Eppo interface](https://eppo.cloud/configuration/environments/keys).
+:::
+
+### Assign a variant
+
+Once initialized, you can get an instance of the client and start making assignments:
+
+```python
+client = eppo_client.get_instance()
+user = get_current_user()
+
+variation = client.get_string_assignment(
+    'show-new-feature', 
+    user.id, 
+    { 'country': user.country }, 
+    'control'
+)
+
+if variation == "variant-a":
+    handle_variant_a()
+elif variation == "variant-b":
+    handle_variant_b()
+else:
+    handle_control()
+```
+
+### Assignment Types
+
+The SDK provides different assignment functions based on the type of value you need:
+
+| Function | Return Type |
+|----------|-------------|
+| `get_string_assignment()` | String |
+| `get_boolean_assignment()` | Boolean |
+| `get_json_assignment()` | JSON object |
+| `get_integer_assignment()` | Integer |
+| `get_numeric_assignment()` | Float |
+
+:::note
+See more details about assignment functions in the [Assignments](/sdks/server-sdks/python/assignments) page.
+:::
+
+## Experiments
+
+While feature flags are useful, they do not send you any information about how your users are interacting with the feature. Experiments provide a way to collect data about these interactions using your preferred logging system.
+
+To log events through the SDK, you need to implement the `AssignmentLogger` class:
+
+```python
+from eppo_client.assignment_logger import AssignmentLogger
+
+class MyLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        print(f"Logging assignment: {assignment}")  # Replace with your logging logic
+
+client_config = Config(
+    api_key="<SDK-KEY>",
+    assignment_logger=MyLogger()
+)
+eppo_client.init(client_config)
+```
+
+:::note
+In a production application, you would want to replace the print statement with an actual logging system. We have documentation on how to set up logging with multiple popular data warehouses and logging systems in the [Assignments page](/sdks/server-sdks/python/assignments/#logging-data-to-your-data-warehouse).
+:::
+
+## Contextual Bandits
+
+Contextual Multi-Armed Bandits are a way to dynamically optimize assignments based on user context. A bandit balances exploration of new actions with exploitation of known successful actions to maximize a specified metric.
+
+### Bandit Setup
+
+Setting up a bandit requires implementing both an assignment logger and a bandit logger:
+
+```python
+from eppo_client.assignment_logger import AssignmentLogger
+
+class MyLogger(AssignmentLogger):
+    def log_assignment(self, assignment):
+        print(f"Logging assignment: {assignment}")
+        
+    def log_bandit_action(self, bandit_action):
+        print(f"Logging bandit action: {bandit_action}")
+
+client_config = Config(
+    api_key="<SDK-KEY>",
+    assignment_logger=MyLogger()
+)
+eppo_client.init(client_config)
+```
+
+### Query the bandit for actions
+
+Instead of making simple assignments with a bandit, you query the bandit for actions:
+
+```python
+import eppo_client
+from eppo_client.bandit import Attributes
+
+client = eppo_client.get_instance()
+bandit_result = client.get_bandit_action(
+    "shoe-bandit",
+    user.id,
+    Attributes(
+        numeric_attributes={"age": user.age},
+        categorical_attributes={"country": user.country}
+    ),
+    {
+        "nike": Attributes(
+            numeric_attributes={"brand_affinity": 2.3},
+            categorical_attributes={"previously_purchased": True},
+        ),
+        "adidas": Attributes(
+            numeric_attributes={"brand_affinity": 0.2},
+            categorical_attributes={"previously_purchased": False},
+        ),
+    },
+    "control"
+)
+
+if bandit_result.action:
+    show_shoe_ad(bandit_result.action)
+else:
+    show_default_ad()
+```
+
+:::note
+For full steps to create a bandit including UI steps, see the [bandit quickstart](/bandit-quickstart).
+:::
+
+## Next Steps
+
+Now that you've seen how to make assignments with the Eppo Python SDK, we recommend familiarizing yourself with:
+
+- [High Level concepts for the server API](/sdks/server-sdks)
+- [Initialization Configuration](/sdks/server-sdks/python/initialization)
+- [Assignment details](/sdks/server-sdks/python/assignments) 

--- a/static/_redirects
+++ b/static/_redirects
@@ -149,3 +149,14 @@ http://adoring-yonath-6ecb9d.netlify.app/*  http://docs.geteppo.com/:splat  301!
 /sdks/server-sdks/rust#assignment-logging-for-experiments /sdks/server-sdks/rust/assignments#assignment-logger-schema
 /sdks/server-sdks/rust#typed-assignment-calls /sdks/server-sdks/rust/assignments#assignment-types
 
+/sdks/server-sdks/python/#getting-started /sdks/server-sdks/python/quickstart
+/sdks/server-sdks/python/#usage /sdks/server-sdks/python/assignments
+/sdks/server-sdks/python/#initialization-options /sdks/server-sdks/python/initialization#initialization-options
+/sdks/server-sdks/python/#contextual-bandits /sdks/server-sdks/python/bandits
+/sdks/server-sdks/python/#advanced-options /sdks/server-sdks/python/initialization#advanced-configuration
+/sdks/server-sdks/python/#examples /sdks/server-sdks/python/examples
+/sdks/server-sdks/python/#assignment-logger-schema /sdks/server-sdks/python/assignments#assignment-logger-schema
+/sdks/server-sdks/python/#logging-to-your-data-warehouse /sdks/server-sdks/python/assignments#logging-to-your-data-warehouse
+/sdks/server-sdks/python/#deduplicating-logs /sdks/server-sdks/python/assignments#deduplicating-logs
+/sdks/server-sdks/python/#waiting-for-configuration /sdks/server-sdks/python/initialization#waiting-for-configuration
+/sdks/server-sdks/python/#usage-in-serverless-environments /sdks/server-sdks/python/initialization#usage-in-serverless-environments


### PR DESCRIPTION
## What?

Updating the Python docs to follow the same multipage pattern as our Javascript docs.

## Why?

- The goal is to make the learning journey for engineers working with specific SDKs easier.
- Content is easier to find in the TOC, improving navigability.
- Code samples for typed assignment examples have been added for ease of use.
- Boilerplate prose docs have been added to allow engineers to learn about relevant conceptual information alongside the code without having to context switch to other parts of the docs.

## Review instructions

- Let's discuss the Python SDK 4.0 announcement doc. Are there any places in the docs where the differences between 3.0 and 4.0 are different enough that we need to preserve older doc information? Are we safe to get rid of that page?
- Please make sure the code samples are accurate.

## Todo before merge

- [ ] Delete python.md
- [ ] Delete announcing-python-4-0.md
- [ ] Update redirects