### PR TITLE
docs(ruby,python): add documentation for pre-forking servers

### DIFF
--- a/docs/sdks/preforking.md
+++ b/docs/sdks/preforking.md
@@ -26,7 +26,7 @@ def initialize_eppo():
 
 ### Spring Example
 
-For Ruby applications using Spring, you can use the `after_fork` callback:
+For Ruby applications using Spring, you can use the `after_fork` callback in `config/spring.rb`:
 
 ```ruby
 Spring.after_fork do

--- a/docs/sdks/preforking.md
+++ b/docs/sdks/preforking.md
@@ -8,7 +8,7 @@ Pre-forking is particularly effective for web servers with long initialization t
 
 Pre-forking is great but it's a tricky/advanced optimization technique and it may cause problems if not used carefully. In particular, forking is incompatible with multi-threading because only the calling thread is copied over to the forked process and the rest of the threads just "disappear" from the process. This may cause some parts of the server not working or leave the system in inconsistent state and cause hangs or crashes.
 
-During initialization, **Python** and **Ruby** Eppo SDKs create a native thread that is responsible for fetching and refreshing Eppo configuration. This is done to offload work from the main thread, so your code can run 100% of the time. Because of this, it is important that Python and Ruby SDKs are not initialized before pre-forking.
+During initialization, **Python** and **Ruby** Eppo SDKs create a native thread that is responsible for fetching and refreshing Eppo configuration. This is done to offload work from the main thread, so your code can run 100% of the time. Because of this, it is important that Python and Ruby SDKs are **not** initialized before pre-forking.
 
 To avoid issues, defer the initialization of Eppo SDK until after the forking process is complete. Most pre-forking servers provide lifecycle hooks that allow you to execute custom logic after the fork. Use these hooks to initialize the SDK.
 

--- a/docs/sdks/preforking.md
+++ b/docs/sdks/preforking.md
@@ -1,0 +1,35 @@
+# Using Eppo SDK with pre-forking servers
+
+Pre-forking is a strategy used by certain server runtimes, like uWSGI and Spring, to improve performance. In this model, the server creates a pool of worker processes by forking from a single main process. This approach avoids the overhead of repeatedly initializing the server and the framework. Instead, initialization is only done once and the process is "copied" to workers in ready state.
+
+Pre-forking is particularly effective for web servers with long initialization times, as it speeds up the process of spawning new workers.
+
+## Things to keep in mind
+
+Pre-forking is great but it's a tricky/advanced optimization technique and it may cause problems if not used carefully. In particular, forking is incompatible with multi-threading because only the calling thread is copied over to the forked process and the rest of the threads just "disappear" from the process. This may cause some parts of the server not working or leave the system in inconsistent state and cause hangs or crashes.
+
+During initialization, **Python** and **Ruby** Eppo SDKs create a native thread that is responsible for fetching and refreshing Eppo configuration. This is done to offload work from the main thread, so your code can run 100% of the time. Because of this, it is important that Python and Ruby SDKs are not initialized before pre-forking.
+
+To avoid issues, defer the initialization of Eppo SDK until after the forking process is complete. Most pre-forking servers provide lifecycle hooks that allow you to execute custom logic after the fork. Use these hooks to initialize the SDK.
+
+### uWSGI Example
+
+In uWSGI, you can use the post-fork hook to ensure the library is initialized in each worker process:
+```python
+import eppo_client
+from uwsgidecorators import postfork
+
+@postfork
+def initialize_eppo():
+    eppo_client.init(eppo_client.ClientConfig(...))
+```
+
+### Spring Example
+
+For Ruby applications using Spring, you can use the `after_fork` callback:
+
+```ruby
+Spring.after_fork do
+  EppoClient::init(EppoClient::Config.new(...))
+end
+```

--- a/docs/sdks/server-sdks/python/index.md
+++ b/docs/sdks/server-sdks/python/index.md
@@ -32,6 +32,10 @@ client_config = Config(api_key="<SDK-KEY-FROM-DASHBOARD>")
 eppo_client.init(client_config)
 ```
 
+:::note
+When using pre-forking web servers (e.g., uWSGI), it's important to initialize Eppo SDK after forking process is complete. See [Using Eppo SDK with pre-forking servers](/sdks/preforking/) for more information.
+:::
+
 #### Assign anywhere
 
 ```python

--- a/docs/sdks/server-sdks/ruby/initialization.mdx
+++ b/docs/sdks/server-sdks/ruby/initialization.mdx
@@ -18,6 +18,10 @@ config = EppoClient::Config.new('<SDK-KEY>')
 EppoClient::init(config)
 ```
 
+:::note
+When using pre-forking web servers (e.g., Spring), it's important to initialize Eppo SDK after forking process is complete. See [Using Eppo SDK with pre-forking servers](/sdks/preforking/) for more information.
+:::
+
 ## Use the SDK instance
 
 After initialization, you can get an instance of the client using Ruby's singleton pattern:

--- a/docs/sdks/server-sdks/ruby/initialization.mdx
+++ b/docs/sdks/server-sdks/ruby/initialization.mdx
@@ -196,6 +196,7 @@ config = EppoClient::Config.new(
   poll_interval_seconds: nil,  # Disable polling
   initial_configuration: offline_config
 )
+```
 
 ### Frameworks
 

--- a/docs/sdks/server-sdks/ruby/initialization.mdx
+++ b/docs/sdks/server-sdks/ruby/initialization.mdx
@@ -196,3 +196,34 @@ config = EppoClient::Config.new(
   poll_interval_seconds: nil,  # Disable polling
   initial_configuration: offline_config
 )
+
+### Frameworks
+
+When using the SDK in Rails, Spring or other frameworks that have their own initialization process, 
+you can initialize the SDK after the framework has initialized.
+
+See details on pre-fork behavior in [Using Eppo SDK with pre-forking servers](/sdks/preforking/).
+
+After initialization, you can use the client singleton to get the client instance:
+
+```ruby
+eppo_client = EppoClient::Client.instance
+```
+
+#### Rails
+
+```ruby
+# In config/initializers/eppo.rb
+EppoClient::init(EppoClient::Config.new('<SDK-KEY>'))
+```
+
+#### Spring
+
+```ruby
+# In config/spring.rb
+require 'eppo_client'
+
+Spring.after_fork do
+    EppoClient::init(EppoClient::Config.new('<SDK-KEY>'))
+end
+```


### PR DESCRIPTION
Add documentation for using Python/Ruby SDKs with pre-forking web servers