### PR TITLE
added assignment logger as an input for ClientConfig

### DIFF
--- a/docs/sdks/server-sdks/python/initialization.mdx
+++ b/docs/sdks/server-sdks/python/initialization.mdx
@@ -15,7 +15,10 @@ To complete basic initialization, you only need to provide an SDK key. [Create a
 import eppo_client
 from eppo_client import ClientConfig, AssignmentLogger
 
-client_config = ClientConfig(api_key="<SDK-KEY>", assignment_logger=AssignmentLogger())
+client_config = ClientConfig(
+  api_key="<SDK-KEY>", 
+  assignment_logger=AssignmentLogger()
+)
 eppo_client.init(client_config)
 ```
 

--- a/docs/sdks/server-sdks/python/initialization.mdx
+++ b/docs/sdks/server-sdks/python/initialization.mdx
@@ -13,9 +13,9 @@ To complete basic initialization, you only need to provide an SDK key. [Create a
 
 ```python
 import eppo_client
-from eppo_client import ClientConfig
+from eppo_client import ClientConfig, AssignmentLogger
 
-client_config = ClientConfig(api_key="<SDK-KEY>")
+client_config = ClientConfig(api_key="<SDK-KEY>", assignment_logger=AssignmentLogger())
 eppo_client.init(client_config)
 ```
 

--- a/docs/sdks/server-sdks/python/quickstart.mdx
+++ b/docs/sdks/server-sdks/python/quickstart.mdx
@@ -29,9 +29,9 @@ First, initialize the SDK using your SDK key:
 
 ```python
 import eppo_client
-from eppo_client import ClientConfig
+from eppo_client import ClientConfig, AssignmentLogger
 
-client_config = ClientConfig(api_key="<SDK-KEY>")
+client_config = ClientConfig(api_key="<SDK-KEY>", assignment_logger=AssignmentLogger())
 eppo_client.init(client_config)
 ```
 
@@ -85,7 +85,8 @@ While feature flags are useful, they do not send you any information about how y
 To log events through the SDK, you need to implement the `AssignmentLogger` class:
 
 ```python
-from eppo_client import AssignmentLogger
+import eppo_client
+from eppo_client import ClientConfig, AssignmentLogger
 
 class MyLogger(AssignmentLogger):
     def log_assignment(self, assignment):
@@ -111,7 +112,8 @@ Contextual Multi-Armed Bandits are a way to dynamically optimize assignments bas
 Setting up a bandit requires implementing both an assignment logger and a bandit logger:
 
 ```python
-from eppo_client import AssignmentLogger
+import eppo_client
+from eppo_client import ClientConfig, AssignmentLogger
 
 class MyLogger(AssignmentLogger):
     def log_assignment(self, assignment):

--- a/docs/sdks/server-sdks/python/quickstart.mdx
+++ b/docs/sdks/server-sdks/python/quickstart.mdx
@@ -31,7 +31,10 @@ First, initialize the SDK using your SDK key:
 import eppo_client
 from eppo_client import ClientConfig, AssignmentLogger
 
-client_config = ClientConfig(api_key="<SDK-KEY>", assignment_logger=AssignmentLogger())
+client_config = ClientConfig(
+    api_key="<SDK-KEY>", 
+    assignment_logger=AssignmentLogger()
+)
 eppo_client.init(client_config)
 ```
 


### PR DESCRIPTION
The SDK will throw an error if `assignment_logger` is not specified in `ClientConfig`. This updates the quickstart and initialization pages to account for this.

I also made the imports more explicit for the experiment and bandit sections of the quickstart, in case the reader skipped over the flagging section