### PR TITLE
Update holdouts documentation

### DIFF
--- a/docs/experiment-analysis/holdouts.md
+++ b/docs/experiment-analysis/holdouts.md
@@ -32,8 +32,8 @@ a holdout group. Held out subjects will have the default experience and the SDK 
 #### Experiment eligibility
 
 * New experiment assignments that start and end within the holdout window will have the holdout applied
-  * Previously created experiments that started within a newly created holdout window will not retroactively have the 
-holdout applied
+  * Any experiment assignment that was created before the holdout was created will not have a holdout applied, regardless 
+of dates for holdout assignment
   * Experiment assignments that start after the holdout window will not have the holdout applied
 * Experiments assignments that start during the holdout window but do not end in that time, will continue to have the 
 holdout applied until the experiment ends

--- a/docs/experiment-analysis/holdouts.md
+++ b/docs/experiment-analysis/holdouts.md
@@ -1,6 +1,6 @@
 # Holdouts
 
-Eppo's Holdouts allows you to validate the aggregate impact of Experimentation.
+Eppo's holdouts allows you to validate the aggregate impact of Experimentation.
 
 This functionality offers the ability to set a holdout audience in feature flags that keeps an audience isolated from all active experiments, and measures metric changes for the holdout audience versus an audience that only experiences winning experiments.
 
@@ -10,121 +10,136 @@ The feature can be used with Eppo's SDK for an end-to-end managed experiment or 
 
 Begin by [configuring your Assignment Source](/data-management/definitions/assignment-sql) to annotate your holdout columns.
 
-### Journey of a Holdout user
+### Journey of a holdout subject
 
-Define one or more holdout groups with a relevant key and the desired active date range. You can have multiple holdout groups running at once (e.g one for each team that runs experiments).
+Define one or more holdout groups with a relevant key and the desired active date range. You can have multiple holdout 
+groups running at once (e.g., one for each team that runs experiments).
 
-The holdout is split into two groups: `status quo` who always see the control experience, and `winning variants` who see the treatment from experiments that are rolled out.
+The holdout is randomly split into two groups:
+* Status Quo: Subjects in this group will always see the default experience for any experiments that take place during the 
+holdout period (holdout variation key `status_quo`)
+* Winning Variants: Subjects in this group will see the winning variant of each experiment after it has been concluded and 
+rolled out (holdout variation key `all_shipped`)
 
 ![Creating a Holdout](/img/experiments/holdouts/holdouts-create-object.png)
 
 ### Assignment period
 
-1. Create experiments on your own schedule.
-2. When subjects are assigned to eligible experiments (more details below) with an active Holdout, 
-Eppo's SDK may assign them to a `holdout` group. The assignments `control` and `holdout` should lead to the same end user experience.
-For this cohort the SDK will return the `control` variation.
+1. Experiment assignments are added to flags
+2. When subjects are assigned to eligible experiments (more details below) with an active holdout, they may be part of 
+a holdout group. Held out subjects will have the default experience and the SDK will return the default variation.
 
-*Eligible experiments*
+#### Experiment eligibility
 
-* Any experiment allocation that starts after the start date will have a holdout applied.
-* Any experiment allocations that starts after the end date will not have a holdout applied
-* Experiments allocation that start during the assignment window but do not end in that time, will have the holdout applied but not included in the analysis. In this case some traffic is wasted.
+* New experiment assignments that start and end within the holdout window will have the holdout applied
+  * Old experiments that started within a newly created holdout window will not retroactively have the holdout applied
+  * Experiment assignments that start after the holdout window will not have the holdout applied
+* Experiments assignments that start during the holdout window but do not end in that time, will continue to have the 
+holdout applied until the experiment ends
+  * To include these experiments in the holdout _analysis_, you can extend the analysis end date beyond the holdout window end 
+date
 
-3. Once an experiment is complete and a winning variation is selected, all non-holdout users (variations and control) will receive it. Users will now either get assigned the winning variant or `holdout`.
-4. Run as many experiments as you want by repeating these steps.
+#### Concluding experiments
 
-### Evaluation period
+Once an experiment is complete and a winning variation is selected, all non-holdout users (variations and control) will receive it.
+Held out users will either be assigned the status quo variation or the winning variation depending on which split of the
+holdout they are a part of.
 
-You may begin an analysis at the conclusion of your desired assignment period by creating a Holdout Experiment.
+### Holdout analysis period
 
-![Creating a Holdout Experiment](/img/experiments/holdouts/holdouts-create-experiment.png)
+You can analyze the holdout by creating a holdout analysis.
 
-1. The evaluation is ongoing and newly shipped winning variations will be added to it automatically.
-2. For that holdout group, after the evaluation period finishes, end the holdout group. 
-3. A report can now be generated reflecting data from the evaluation period showing how the holdout group did against users who saw all experiment winners.
+![Creating a Holdout Analysis](/img/experiments/holdouts/holdouts-create-experiment.png)
 
-### SDK Behavior
+* Any experiments with rolled out variations during the holdout will be included
+* Experiments that are in progress will be added to the analysis automatically when winning variations are rolled out
+* The analysis will evaluate the impact to the selected metrics on the held out subjects who received the winning
+variations compared to those who received the status quo variations
 
-Application developers should expect no changes to the SDKs.
+### SDK behavior
 
-For the correctness of Holdout Analysis to take place, the experience of
-subjects assigned to a Holdout should match those in the `control` of each 
-experiment during the enrollment phase.
-
-When invoking the `get*Assignment` methods with a subject and flag keys,
-subjects assigned to a Holdout will have the `control` variation returned.
-This makes it foolproof to design your User Experience without worrying
-about handling a special case.
+Application developers do not need to make any changes to the SDK usage other than ensuring holdout information passed
+to the assignment logger is properly sent to the warehouse.
 
 ![Data Flow](/img/experiments/holdouts/holdouts-data-flow.png)
 
 ### Changes to assignment logging
 
-The callback function is augmented with a `holdout` value if the `subject`
-was assigned to one. This should be transmitted to your Data Warehouse
-to facilitate filtering and computation of lifts.
+Subjects who are in hold out groups will always be assigned the status quo variation for any qualifying experiments that
+are in progress. Assignment logging will use a holdout-specific assignment (allocation) and experiment keys so that it
+doesn't interfere with the experiment analysis for subjects not being held out. These keys--passed as the `allocation` 
+and `experiment` properties of the assignment event, are composite keys that end with the key of the applied holdout
+(e.g., `homepage-experiment-holdout-2025Q1`)
 
-An example in GoLang:
+Once the experiment concludes, if a variation is rolled out, then half of held out subjects--those bucketed into the winning 
+variation split of the holdout group--will start being assigned the rolled out variation.
 
-```go
-import (
-  "gopkg.in/segmentio/analytics-go.v3"
-)
+To facilitate analysis of the holdout group across _all_ qualifying rollouts, there is additional information that is 
+included in the assignment event that is passed to the assignment logger:
+* The holdout key - unique identifier for the holdout group
+* The holdout variation - whether the subject is in the status quo (`status_quo`) or winning variation (`all_shipped`) 
+split of the holdout
 
-...
-
-type ExampleAssignmentLogger struct {}
-
-func (al *ExampleAssignmentLogger) LogAssignment(event eppoclient.AssignmentEvent) {
-    client.Enqueue(analytics.Track{
-        UserId: event.Subject,
-        Event:  "Eppo Randomization Event",
-        HoldoutKey: event.Holdout
-    })
-}
+For example, in Python:
+```python
+class MyAssignmentLogger(AssignmentLogger):
+    def log_assignment(self, event):
+        print("Send to warehouse", { 
+            'timestamp': event['timestamp'],
+            'experimentKey': event['experiment'],
+            'holdoutKey':  event['holdoutKey'], 
+            'holdoutVariation': event['holdoutVariation'],
+            # other fields from event as desired
+        })
 ```
 
-## Analysis-Only Holdouts
+## Analysis-only holdouts
 
-If your Holdouts are deployed by an external randomization library and you are not using Eppo's feature flags, please refer to this section.
+If your holdouts are deployed by an external randomization library, and you are not using Eppo's feature flags, please refer to this section.
 
-Eppo enables you to bring your own Holdouts and provides a full-featured analysis of that Holdout on key metrics.
+Eppo enables you to bring your own holdouts and provides a full-featured analysis of that holdout on key metrics.
 
 ### Assignment setup
 
-While Eppo is flexible to how you configure Holdouts on your end, we recommend you setup your Holdouts in the following fashion:
-* There should be two variants: `status_quo` and `winning_variants`
+While Eppo is flexible to how you configure holdouts on your end, we recommend that you set up your holdouts in the following fashion:
+* There should be two variants: `status_quo` and `all_shipped`
 * Traffic should be evenly split between these variants within your withheld traffic group
 * Users in `status_quo` should always see the control experience until the holdout is released
-* Users in `winning_variants` should be exposed to the winning variant of each experiment after it has been concluded and rolled out
+* Users in `all_shipped` should be exposed to the winning variant of each experiment after it has been concluded and rolled out
 
 Ensure you are logging exposure to the holdout and each variant in an Assignment Source. Eppo requires the following information:
-*  An `experiment key` which is the name of the Holdout the user is enrolled in
-*  The `variant` name that the user is enrolled in for the applicable Holdout
+*  An `experiment key` which is the name of the holdout the user is enrolled in
+*  The `variant` name that the user is enrolled in for the applicable holdout
 
-With this setup, Holdouts will be logged with Experiments in AssignmentSQL that is setup in Eppo.
+With this setup, holdouts will be logged with experiments in AssignmentSQL that is set up in Eppo.
 
 ![Verify assignment source](/img/experiments/holdouts/standalone-assignment-sql.png)
 
-### Configuring a Holdouts Analysis
+### Configuring a holdouts analysis
 
-Create a new Holdout experiment over your desired date range by clicking on the "+Create" button on the Analysis tab.
+Create a new holdout analysis over your desired date range by clicking on the "Create Analysis" button on the Analysis tab.
 
-Configure the analysis with the variation names in your holdout, such as `status_quo` and `winning_variants`.  This allows the Eppo generated SQL to correctly query the data in your warehouse.
+Name the analysis, select which entity is the subject of the analysis (e.g., User), and an assignment source.
+
+Select a holdout key, which will be the key for the experiment.
+
+Configure the analysis with the variation names in your holdout, such as `status_quo` and `all_shipped`.
+This allows the Eppo generated SQL to correctly query the data in your warehouse.
 
 ![Configure variations](/img/experiments/holdouts/standalone-variations.png)
 
-You are able to link experiments to your holdout to provide a comprehensive report of how each experiment impacted the primary Holdout metric and show the experience provided by the winning variants. To do so, go to the Overview tab and add Experiments that are part of the Holdout. Note that these experiments must be configured in Eppo to be linked.
+On the Overview tab, you are able to link experiments to your holdout to conduct an analysis of how each experiment 
+impacted the primary holdout metric and show the experience provided by the winning variants.
+
+To do so, go to the Overview tab and add experiments that are part of the holdout. Note that these experiments must be 
+configured in Eppo to be linked.
 
 ![Create a stand-alone analysis](/img/experiments/holdouts/analysis-only-setup1.png)
 
-## Holdout Analysis
+## Holdout analysis
 
-Regardless of whether you use Eppo's SDK or your own, the artifact will be a report detailing impact of the holdout variation over the control,
-with annotations display the shipped experiments.
-
-Lift on the primary metric will be computed across the winning variants comparing the holdout subjects against everyone else.
+Regardless of whether you use Eppo's SDK or your own, the analysis will detail the impact of the winning variations over
+the status quo.
 
 ![View Holdout Report](/img/experiments/holdouts/holdouts-report.png)
 

--- a/docs/experiment-analysis/holdouts.md
+++ b/docs/experiment-analysis/holdouts.md
@@ -32,7 +32,8 @@ a holdout group. Held out subjects will have the default experience and the SDK 
 #### Experiment eligibility
 
 * New experiment assignments that start and end within the holdout window will have the holdout applied
-  * Old experiments that started within a newly created holdout window will not retroactively have the holdout applied
+  * Previously created experiments that started within a newly created holdout window will not retroactively have the 
+holdout applied
   * Experiment assignments that start after the holdout window will not have the holdout applied
 * Experiments assignments that start during the holdout window but do not end in that time, will continue to have the 
 holdout applied until the experiment ends
@@ -128,11 +129,10 @@ This allows the Eppo generated SQL to correctly query the data in your warehouse
 
 ![Configure variations](/img/experiments/holdouts/standalone-variations.png)
 
-On the Overview tab, you are able to link experiments to your holdout to conduct an analysis of how each experiment 
-impacted the primary holdout metric and show the experience provided by the winning variants.
-
-To do so, go to the Overview tab and add experiments that are part of the holdout. Note that these experiments must be 
-configured in Eppo to be linked.
+On the Overview tab, you are able to link experiments to your holdout to provide a comprehensive report of how each 
+experiment impacted the primary Holdout metric and show the experience provided by the winning variants. To do so, go to
+the Overview tab and add experiments that are part of the holdout. Note that these experiments must be configured in Eppo
+to be linked.
 
 ![Create a stand-alone analysis](/img/experiments/holdouts/analysis-only-setup1.png)
 


### PR DESCRIPTION
🎟️ **Ticket:** [FF-3808](https://linear.app/eppo/issue/FF-3808/)
🗨️ **Slack Convo:** ["... getting the assignment data is key..."](https://eppo-group.slack.com/archives/C030T4F1NFN/p1737135810104969?thread_ts=1736856747.908079&cid=C030T4F1NFN)

The existing holdout documentation was confusing in some places, particularly with regard to how holdouts are handled in assignment logging.

This PR gives it a once-over to address this confusion.

We've also updated it to reflect some recently made UX changes, such as treating the default variation as the status quo.

👀 👉 **Direct preview link:** [Core Concepts - Experiment Analysis - Holdouts](https://deploy-preview-575--eppo-data-docs.netlify.app/experiment-analysis/holdouts/)