### PR TITLE
feat: Add new event tracking page

### DIFF
--- a/docs/data-management/definitions/assignment-sql.md
+++ b/docs/data-management/definitions/assignment-sql.md
@@ -73,7 +73,7 @@ We'll now provide a step-by-step walkthrough for creating Assignment SQL Definit
 ![Write Assignment SQL Query](/img/building-experiments/add-assignment-sql-query.png)
 
 :::info
-If you do not yet have assignment logs in your warehouse, see the [Event Logging page](/sdks/event-logging).
+If you do not yet have assignment logs in your warehouse, see the [Assignment Event Logging page](/sdks/assignment-event-logging).
 :::
 
 5. After clicking **Run**, you'll see some sample data. Annotate these columns into Eppo's data model using the right panel:

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -21,5 +21,5 @@ Don't hesitate to shoot us an email at support@geteppo.com.
 
 ## Experimentation
 
-- Learn how to set up [event logging](/sdks/event-logging/) with Segment, Rudderstack, mParticle, or Snowplow.
+- Learn how to set up [assignment event logging](/sdks/event-logging/assignment-event-logging/) with Segment, Rudderstack, mParticle, or Snowplow.
 - Analyze experiments with [anonymous user IDs](/guides/advanced-experimentation/anonymous-explainer).

--- a/docs/guides/marketing/integrating-with-webflow.md
+++ b/docs/guides/marketing/integrating-with-webflow.md
@@ -109,7 +109,7 @@ window.eppo.init(opts).then(setHeader);
 
 - Provide your SDK key and Feature Flag key in the `'<SDK-KEY>'` and `'<FEATURE-FLAG-KEY>'` placeholders above.
 - Provide the id you are going to use for analytics logging to `'<SUBJECT-ID>'`. Ideally this would be an id from a managed platform such as Segment, Rudderstack, Google Analytics, or an internal platform.
-- Add your client side analytics tracking call once the assignment has been made. Make sure your analytics platform is sending data to your data warehouse connected to Eppo. This will ensure that assignments made by Eppo will be tracked and can be used for experiment analysis. For more information on Eppo's event logging integrations with popular platforms like Segment, mParticle, Rudderstack, and Snowplow, see our documentation [here](/sdks/event-logging).
+- Add your client side analytics tracking call once the assignment has been made. Make sure your analytics platform is sending data to your data warehouse connected to Eppo. This will ensure that assignments made by Eppo will be tracked and can be used for experiment analysis. For more information on Eppo's event logging integrations with popular platforms like Segment, mParticle, Rudderstack, and Snowplow, see our documentation [here](/sdks/assignment-event-logging).
 
 ## Edge cases
 
@@ -120,4 +120,3 @@ If you end up using a subject key or user traits from a cookie, make sure that t
 ## Demo
 
 To see a demo of the Webflow integration in action, see this link: https://star-wars-demo.webflow.io/. 
-

--- a/docs/guides/migrations/launchdarkly-migration.md
+++ b/docs/guides/migrations/launchdarkly-migration.md
@@ -3,7 +3,7 @@
 1. **Install the Eppo SDK**
     - Login to Eppo with your work email: https://eppo.cloud/
     - [Generate an SDK key](https://docs.geteppo.com/sdks/sdk-keys) by navigating to “SDK Keys” under Configuration
-    - [Define a logging function](https://docs.geteppo.com/sdks/event-logging/) for the Eppo SDK to log assignments so they end up in your data warehouse.
+    - [Define a logging function](https://docs.geteppo.comsdks/event-logging/assignment-event-logging/) for the Eppo SDK to log assignments so they end up in your data warehouse.
       
       *TypeScript Example:*
         

--- a/docs/guides/migrations/optimizely-migration.md
+++ b/docs/guides/migrations/optimizely-migration.md
@@ -3,7 +3,7 @@
 1. **Install the Eppo SDK**
     - Login to Eppo with your work email: https://eppo.cloud/
     - [Generate an SDK key](/sdks/sdk-keys) by navigating to “SDK Keys” under Configuration
-    - [Define a logging function](/sdks/event-logging/) for the Eppo SDK to log assignments so they end up in your data warehouse
+    - [Define a logging function](/sdks/event-logging/assignment-event-logging/) for the Eppo SDK to log assignments so they end up in your data warehouse
         
         *TypeScript Example:*
         

--- a/docs/quick-starts/bandit-quickstart.md
+++ b/docs/quick-starts/bandit-quickstart.md
@@ -27,7 +27,7 @@ Store the SDK key securely; it is not possible to view it after closing the moda
 
 Eppo leverages your existing event logging infrastructure to track experiment assignments. Whether you use a third-party system to log events to the data warehouse or have an internally built solution, you'll simply pass in a logging function when initializing the SDK.
 
-The [event logging](/sdks/event-logging/) page has more information on how to set up logging using different logging tools.
+The [Assignment event logging](/sdks/event-logging/assignment-event-logging/) page has more information on how to set up logging using different logging tools.
 
 This logger should write to a table with columns with the following names (they can be in any order):
 * **timestamp** - Timestamp of the bandit assignment
@@ -46,7 +46,7 @@ Additional information that is provided to the logger that can optionally--but i
 * **optimality_gap** - The difference between the score of the selected action and the highest-scored action
 * **metadata** - Any additional freeform metadata, in JSON format, such as the version of the SDK
 
-Below is an example bandit assignment logger for the Java SDK, defined when building the SDK client. This example writes directly to Snowflake. This is illustrative and not recommended practice. Refer to our [event logging](/sdks/event-logging/) page for recommended options.
+Below is an example bandit assignment logger for the Java SDK, defined when building the SDK client. This example writes directly to Snowflake. This is illustrative and not recommended practice. Refer to our [assignment event logging](/sdks/event-logging/assignment-event-logging/) page for recommended options.
 
 ```java
 .banditLogger(logData -> {

--- a/docs/sdks/event-logging/_category_.json
+++ b/docs/sdks/event-logging/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Event Logging",
+  "position": 4
+}

--- a/docs/sdks/event-logging/assignment-event-logging.md
+++ b/docs/sdks/event-logging/assignment-event-logging.md
@@ -1,15 +1,11 @@
----
-sidebar_position: 4
----
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Event logging
+# Assignment Event logging
 
 In order to run experiments on Eppo you'll need to provide a logging callback function to write assignment events to your warehouse. It is best practice to centralize application logging as much as possible, and Eppo's SDKs work seamlessly with most logging tools, meaning you can keep using your favorite logger.
 
-Eppo's SDKs include either an assignment logger base class or an interface, in which you can define a method according to your logging requirements. Examples are [shown below](/sdks/event-logging#examples-for-common-logging-systems) in Eppo's Node SDK for logging with some common event loggers.
+Eppo's SDKs include either an assignment logger base class or an interface, in which you can define a method according to your logging requirements. Examples are [shown below](/sdks/assignment-event-logging#examples-for-common-logging-systems) in Eppo's Node SDK for logging with some common event loggers.
 
 The object passed into the assignment logger function contains the following fields:
 

--- a/docs/sdks/event-logging/event-tracking.md
+++ b/docs/sdks/event-logging/event-tracking.md
@@ -1,0 +1,53 @@
+# Event tracking
+
+The Track API allows you to record any actions your users perform, like "Signed Up", "Made a Purchase" or "Clicked a Button",
+along with any properties that describe the action. Once you send these events, Eppo will ingest them, batch, process and
+load into the data warehouse of your choice. You can then, further analyze them, trigger downstream actions, and generally 
+get better visibility into user behavior.
+
+## Why to use it
+
+* **Deeper Insights**: You get real-time data about how people use your product. That helps you figure out where users might get stuck, what features they love, and what drives them to come back.
+* **Personalized Experiences**: Once you know what actions users are taking, you can customize their experience—like sending personalized messages or recommending features they’d find useful.
+* **Consistent Data Flow**: By centralizing your event tracking with an API call, you keep everything neat and standard across all your different tools (analytics, CRM, marketing platforms, etc.).
+
+## When to Use It
+
+Use the Track API any time you want to record a user’s action. This could be:
+
+* User signs up or completes onboarding;
+* User views specific screens or pages;
+* User interacts with certain in-app features (clicking a button, changing a setting, etc.);
+* Transactions, such as making a purchase or completing a subscription upgrade;
+* You want Eppo to take care of ingesting and processing your event stream.
+
+Here's how a typical event looks like:
+
+```json
+{
+  "type": "added_to_cart",
+  "payload": {
+    "productId": "abc-987",
+    "userId": "123",
+    "price": 24.99
+  }
+}
+```
+
+## Example usage
+
+Here's an example of how you might use the Track API in a Browser application:
+
+```typescript
+import * as EppoSdk from "@eppo/js-client-sdk";
+
+const eppoClient = EppoSdk.getInstance();
+eppoClient.track({
+  type: "added_to_cart",
+  payload: {
+    productId: "abc-987",
+    userId: "123",
+    price: 24.99
+  }
+});
+```

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -87,7 +87,7 @@ await init({
 });
 ```
 
-This `assignmentLogger` function takes a single input: an Eppo-maintained `assignment` analytic event. This function is invoked each time the `get<Type>Assignment` method is called, meaning that once the SDK is installed in your application, engineers need to think about assignment logging. The `assignment` [analytic event](/sdks/event-logging/) contains all of the fields needed for Eppo's analytic engine, including targeting details and holdout group evaluations.
+This `assignmentLogger` function takes a single input: an Eppo-maintained `assignment` analytic event. This function is invoked each time the `get<Type>Assignment` method is called, meaning that once the SDK is installed in your application, engineers need to think about assignment logging. The `assignment` [analytic event](/sdks/event-logging/assignment-event-logging/) contains all of the fields needed for Eppo's analytic engine, including targeting details and holdout group evaluations.
 
 ## Ergonomic API
 

--- a/docs/sdks/server-sdks/go.md
+++ b/docs/sdks/server-sdks/go.md
@@ -142,7 +142,7 @@ The SDK will invoke the `LogAssignment` function with an `event` object that con
 
 
 :::note
-More details about logging and examples (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [event logging](/sdks/event-logging/) page.
+More details about logging and examples (with Segment, Rudderstack, mParticle, and Snowplow) can be found in the [assignment event logging](/sdks/event-logging/assignment-event-logging/) page.
 :::
 
 ## 3. Assign variations

--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Description

* Created a new section in the sidebar with "assignment event logging" and "event tracking" under it 
* Redirected old links to the new page
* Created new page with some initial content for upcoming release

<img width="305" alt="image" src="https://github.com/user-attachments/assets/c8a53b3a-5a19-4898-af74-2b6e1d281c70" />
