### PR TITLE
Added note about "use client" to React docs

### DIFF
--- a/docs/sdks/client-sdks/javascript/react.mdx
+++ b/docs/sdks/client-sdks/javascript/react.mdx
@@ -43,7 +43,7 @@ export default function EppoRandomizationProvider({
 ```
 
 :::note
-If you are using Next.js, make sure this component is rendered client side by adding `"use client"` to the top of the file. For more details on using Eppo in Next.js, see (here)[/sdks/client-sdks/javascript/nextjs-setup/].
+If you are using Next.js, make sure this component is rendered client side by adding `"use client"` to the top of the file. For more details on using Eppo in Next.js, see [here](/sdks/client-sdks/javascript/nextjs-setup/).
 :::
 
 After the SDK is initialized, you may assign variations from any child component of `EppoRandomizationProvider`. We recommend wrapping the SDK code in a [useMemo hook](https://reactjs.org/docs/hooks-reference.html#usememo) to avoid invoking the assignment logic on every render:

--- a/docs/sdks/client-sdks/javascript/react.mdx
+++ b/docs/sdks/client-sdks/javascript/react.mdx
@@ -42,6 +42,10 @@ export default function EppoRandomizationProvider({
 }
 ```
 
+:::note
+If you are using Next.js, make sure this component is rendered client side by adding `"use client"` to the top of the file.
+:::
+
 After the SDK is initialized, you may assign variations from any child component of `EppoRandomizationProvider`. We recommend wrapping the SDK code in a [useMemo hook](https://reactjs.org/docs/hooks-reference.html#usememo) to avoid invoking the assignment logic on every render:
 
 ```tsx

--- a/docs/sdks/client-sdks/javascript/react.mdx
+++ b/docs/sdks/client-sdks/javascript/react.mdx
@@ -43,7 +43,7 @@ export default function EppoRandomizationProvider({
 ```
 
 :::note
-If you are using Next.js, make sure this component is rendered client side by adding `"use client"` to the top of the file.
+If you are using Next.js, make sure this component is rendered client side by adding `"use client"` to the top of the file. For more details on using Eppo in Next.js, see (here)[/sdks/client-sdks/javascript/nextjs-setup/].
 :::
 
 After the SDK is initialized, you may assign variations from any child component of `EppoRandomizationProvider`. We recommend wrapping the SDK code in a [useMemo hook](https://reactjs.org/docs/hooks-reference.html#usememo) to avoid invoking the assignment logic on every render:


### PR DESCRIPTION
We have dedicated Next.js docs, but I figure this is easy enough to get tripped up on that it's worth adding a callout