### PR TITLE
Updated Google Analytics Measurement ID

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ async function createConfig () {
       [
         '@docusaurus/plugin-google-gtag',
         {
-          trackingID: 'G-MPEPCYZCEY', 
+          trackingID: 'G-8VW1T2Y4E8', 
           anonymizeIP: true, // GDPR compliance
         },
       ],


### PR DESCRIPTION
Updated Google Analytics Measurement ID to match Marketing Site to share cross-domain data