### PR TITLE
Require more roles for BigQuery connection

### DIFF
--- a/docs/data-management/connecting-dwh/bigquery.md
+++ b/docs/data-management/connecting-dwh/bigquery.md
@@ -17,6 +17,10 @@ Additionally, you will need to create a data environment for Eppo to write inter
 7. Under **Service account permissions**, add the following roles:
     - `BigQuery Job User (roles/bigquery.jobUser)`
       - Required
+    - `BigQuery User (roles/bigquery.user)`
+      - Required
+    - `BigQuery Darta Viewer (roles/bigquery.dataViewer )`
+      - Required
     - `Storage Admin (roles/storage.admin)`
       - Optional; required for using Eppo's [Track API](/sdks/event-logging/event-tracking)
       - Scoped to the Storage bucket to use for temporary storage of events before loading into BigQuery


### PR DESCRIPTION
A prospect  mentioned that:
> EPPO document describes that the service account needs only roles/bigquery.jobUser .
> Don't need permission to read data?
> For example, roles/bigquery.user, roles/bigquery.dataViewer .
> The reason I asked this question is because I was getting permission errors on my test connection.

with a screen capture that reads:
> Failed to add database connection: Access Denied: Dataset <…>
> Permission bigquery.tables.create denied on dataset <…> (or it may not exist).

I don‘t have easy access to a BigQuery instance to validate that we need more, independently of step 2. and 3. 