### PR TITLE
add flagging webhook and integration instructions (FF-4159)

### DIFF
--- a/docs/reference/webhook.mdx
+++ b/docs/reference/webhook.mdx
@@ -120,7 +120,7 @@ To use the webhook, you first need to setup a URL on your side to receive the we
 
 The configuration is done in the [Admin > Integrations](https://eppo.cloud/admin/integrations) page.
 
-Once that is done, contact [Eppo support](emailto:support@geteppo.com) to set and enable the webhook.
+Once that is done, contact [Eppo support](emailto:support@geteppo.com) to customize the webhook to your needs.
 
 ## Webhook Signature
 

--- a/docs/reference/webhook.mdx
+++ b/docs/reference/webhook.mdx
@@ -1,11 +1,11 @@
 # Webhooks
 
-## Experiment Update Webhook
-
 Webhooks let your integrations take action in response to events that occur in Eppo. 
+
+## Experiment Webhook Events
+
 The Experiment Update Webhook is a good solution when a custom application needs to display or take action on the most up to date state of an experiment.
 
-## Webhook Events
 The webhook sends four types of experiment update events. If you only want to take action based on certain types of events, 
 you can filter to just the events you are interested in subscribing to based on their event type in the request body.
 
@@ -90,11 +90,14 @@ you can filter to just the events you are interested in subscribing to based on 
 
 ## Flagging Webhooks
 
+The flagging webhook is a good solution when a custom application needs to display 
+or take action on the most up to date state of a flag.
+
 ### Flag Configuration Updated
 
-The flag configuration updated webhook is sent when a flag or its associated configuration is updated.
+The flag configuration updated webhook is sent when a flag or its associated models, such as assignments, targeting rules, environments or audiences, are updated.
 
-Any operation visible in the Flag History is sent to the webhook.
+In short, any operation visible in the Flag History is sent to the webhook.
 
 **Request body:**
 

--- a/docs/reference/webhook.mdx
+++ b/docs/reference/webhook.mdx
@@ -4,7 +4,7 @@ Webhooks let your integrations take action in response to events that occur in E
 
 ## Experiment Webhook Events
 
-The Experiment Update Webhook is a good solution when a custom application needs to display or take action on the most up to date state of an experiment.
+This webhook is a good solution when a custom application needs to display or take action on the most up to date state of an experiment.
 
 The webhook sends four types of experiment update events. If you only want to take action based on certain types of events, 
 you can filter to just the events you are interested in subscribing to based on their event type in the request body.
@@ -95,7 +95,7 @@ or take action on the most up to date state of a flag.
 
 ### Flag Configuration Updated
 
-The flag configuration updated webhook is sent when a flag or its associated models, such as assignments, targeting rules, environments or audiences, are updated.
+This webhook is sent when a flag or its associated models, such as assignments, targeting rules, environments or audiences, are updated.
 
 In short, any operation visible in the Flag History is sent to the webhook.
 

--- a/docs/reference/webhook.mdx
+++ b/docs/reference/webhook.mdx
@@ -1,9 +1,13 @@
-# Experiment Update Webhook
+# Webhooks
 
-Webhooks let your integrations take action in response to events that occur in Eppo. The Experiment Update Webhook is a good solution when a custom application needs to display or take action on the most up to date state of an experiment.
+## Experiment Update Webhook
+
+Webhooks let your integrations take action in response to events that occur in Eppo. 
+The Experiment Update Webhook is a good solution when a custom application needs to display or take action on the most up to date state of an experiment.
 
 ## Webhook Events
-The webhook sends four types of experiment update events. If you only want to take action based on certain types of events, you can filter to just the events you are interested in subscribing to based on their event type in the request body.
+The webhook sends four types of experiment update events. If you only want to take action based on certain types of events, 
+you can filter to just the events you are interested in subscribing to based on their event type in the request body.
 
 ### Experiment Metric Updated
 **Triggers when:**
@@ -84,5 +88,87 @@ The webhook sends four types of experiment update events. If you only want to ta
 }
 ```
 
+## Flagging Webhooks
+
+### Flag Configuration Updated
+
+The flag configuration updated webhook is sent when a flag or its associated configuration is updated.
+
+Any operation visible in the Flag History is sent to the webhook.
+
+**Request body:**
+
+```json
+{
+  "event": "flag.configuration.updated",
+  "data": {
+    "flag": {
+      "id": "<flag_id>",
+      "key": "<flag_key>"
+    }
+  },
+  "signature": "<signature>"
+}
+```
+
 ## Configuring the webhook
-To use the webhook, you first need to setup a URL on your side to receive the webhook payload. Once that is done, contact [Eppo support](emailto:support@geteppo.com) to set and enable the webhook.
+
+To use the webhook, you first need to setup a URL on your side to receive the webhook payload.
+
+The configuration is done in the [Admin > Integrations](https://eppo.cloud/admin/integrations) page.
+
+Once that is done, contact [Eppo support](emailto:support@geteppo.com) to set and enable the webhook.
+
+## Webhook Signature
+
+The webhook payload is signed with a signature. The signature is a hash of the payload and the webhook secret.
+
+### Integrating and Verifying the Signature
+
+To verify the webhook signature, you'll need to:
+
+1. Get the signature from the webhook payload
+2. Generate a HMAC SHA-256 hash of the raw request body using your webhook secret
+3. Compare the generated hash with the received signature
+
+Here's an example in TypeScript/Node.js:
+
+```typescript
+import crypto from 'crypto';
+
+function generateHMACSignature(secret: string, payload: string): string {
+  return crypto.createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex');
+}
+
+function isValidWebhookSignature(
+  payload: string,
+  signature: string,
+  webhookSecret: string
+): boolean {
+  const expectedSignature = generateHMACSignature(webhookSecret, payload);
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expectedSignature)
+  );
+}
+
+// Example usage in an Express route handler
+app.post('/webhook', (req, res) => {
+  const signature = req.body.signature;
+  const payload = JSON.stringify(req.body);
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+
+  if (!isValidWebhookSignature(payload, signature, webhookSecret)) {
+    return res.status(401).send('Invalid signature');
+  }
+
+  // Process the webhook
+  // ...
+});
+```
+
+:::note
+Always use a constant-time comparison function (like `crypto.timingSafeEqual`) when comparing signatures to prevent timing attacks.
+:::


### PR DESCRIPTION
## Motivation

* expanding web-hook events to send when a flag configuration changes
* improve docs

## Description

* Add section on new `flag configuration updated` web-hook
* generalize the page away from explicitly experiment centric events
* add integration and signature verification section