### PR TITLE
Typo in SDK’s address in in Golang Quickstart

### DIFF
--- a/docs/sdks/server-sdks/go/assignments.mdx
+++ b/docs/sdks/server-sdks/go/assignments.mdx
@@ -25,7 +25,7 @@ String assignments return a string value that is set as the variation. String fl
 
 ```go
 import (
-    "github.com/eppo-exp/golang-sdk/v6/eppoclient"
+    "github.com/Eppo-exp/golang-sdk/v6/eppoclient"
 )
 
 subjectAttributes := map[string]interface{}{
@@ -146,7 +146,7 @@ The SDK will invoke an assignment logger function if it is available when the as
 
 The SDK will invoke the `LogAssignment` method with an `AssignmentEvent` struct that contains the following fields:
 
-<ApiOptionRef 
+<ApiOptionRef
   name="Timestamp"
   type="string"
   defaultValue='""'
@@ -155,7 +155,7 @@ The SDK will invoke the `LogAssignment` method with an `AssignmentEvent` struct 
 The time when the subject was assigned to the variation in ISO format. Example: `"2021-06-22T17:35:12.000Z"`
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="FeatureFlag"
   type="string"
   defaultValue='""'
@@ -164,7 +164,7 @@ The time when the subject was assigned to the variation in ISO format. Example: 
 An Eppo feature flag key. Example: `"recommendation-algo"`
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="Allocation"
   type="string"
   defaultValue='""'
@@ -173,7 +173,7 @@ An Eppo feature flag key. Example: `"recommendation-algo"`
 An Eppo allocation key. Example: `"allocation-17"`
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="Experiment"
   type="string"
   defaultValue='""'
@@ -182,7 +182,7 @@ An Eppo allocation key. Example: `"allocation-17"`
 An Eppo experiment key. Example: `"recommendation-algo-allocation-17"`
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="Subject"
   type="string"
   defaultValue='""'
@@ -191,7 +191,7 @@ An Eppo experiment key. Example: `"recommendation-algo-allocation-17"`
 An identifier of the subject or user assigned to the experiment variation. Example: UUID
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="SubjectAttributes"
   type="map[string]interface{}"
   defaultValue="nil"
@@ -200,7 +200,7 @@ An identifier of the subject or user assigned to the experiment variation. Examp
 A map of metadata about the subject. These attributes are only logged if passed to the SDK assignment function. Example: `{"country": "US"}`
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="Variation"
   type="string"
   defaultValue='""'
@@ -209,7 +209,7 @@ A map of metadata about the subject. These attributes are only logged if passed 
 The experiment variation the subject was assigned to. Example: `"control"`
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="MetaData"
   type="map[string]string"
   defaultValue="{}"
@@ -217,7 +217,7 @@ The experiment variation the subject was assigned to. Example: `"control"`
 A map of key-value pairs that allows you to attach custom metadata to the assignment event. This metadata is logged alongside the assignment event and can be used for additional context or filtering in analytics.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="ExtraLogging"
   type="map[string]string"
   defaultValue="{}"
@@ -317,7 +317,7 @@ func (l *CachingLogger) LogAssignment(event eppoclient.AssignmentEvent) error {
     if _, exists := l.cache.Get(cacheKey); exists {
         return nil
     }
-    
+
     err := l.wrapped.LogAssignment(event)
     if err == nil {
         l.cache.Add(cacheKey, true)

--- a/docs/sdks/server-sdks/go/initialization.mdx
+++ b/docs/sdks/server-sdks/go/initialization.mdx
@@ -13,7 +13,7 @@ To complete basic initialization, you only need to provide an SDK key. [Create a
 
 ```go
 import (
-    "github.com/eppo-exp/golang-sdk/v6/eppoclient"
+    "github.com/Eppo-exp/golang-sdk/v6/eppoclient"
 )
 
 config := eppoclient.Config{
@@ -46,7 +46,7 @@ Basic initialization is great for most use cases, but the SDK provides options t
 
 The `Config` struct accepts the following options:
 
-<ApiOptionRef 
+<ApiOptionRef
   name="SdkKey"
   type="string"
   defaultValue='""'
@@ -55,7 +55,7 @@ The `Config` struct accepts the following options:
 Your SDK key from the Eppo dashboard. Required.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="AssignmentLogger"
   type="IAssignmentLogger"
   defaultValue="nil"
@@ -64,7 +64,7 @@ Your SDK key from the Eppo dashboard. Required.
 A callback that sends each assignment to your data warehouse. Required only for experiment analysis.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="BaseUrl"
   type="string"
   defaultValue='"https://fscdn.eppo.cloud/api"'
@@ -73,7 +73,7 @@ A callback that sends each assignment to your data warehouse. Required only for 
 The base URL for the Eppo API.
 </ApiOptionRef>
 
-<ApiOptionRef 
+<ApiOptionRef
   name="PollerInterval"
   type="time.Duration"
   defaultValue="10 * time.Second"

--- a/docs/sdks/server-sdks/go/quickstart.mdx
+++ b/docs/sdks/server-sdks/go/quickstart.mdx
@@ -23,7 +23,7 @@ Feature flags are a way to toggle features on and off without needing to deploy 
 
 ### Initialize the SDK
 
-[Create an SDK key](/sdks/sdk-keys) if you don't already have one. 
+[Create an SDK key](/sdks/sdk-keys) if you don't already have one.
 
 First, initialize the SDK using your SDK key:
 
@@ -134,7 +134,7 @@ Setting up a bandit requires implementing both an assignment logger and a bandit
 
 ```go
 import (
-    "github.com/eppo-exp/golang-sdk/v6/eppoclient"
+    "github.com/Eppo-exp/golang-sdk/v6/eppoclient"
 )
 
 type MyLogger struct{}
@@ -220,4 +220,4 @@ Now that you've seen how to make assignments with the Eppo Go SDK, we recommend 
 
 - [High Level concepts for the server API](/sdks/server-sdks)
 - [Initialization Configuration](/sdks/server-sdks/go/initialization)
-- [Assignment details](/sdks/server-sdks/go/assignments) 
+- [Assignment details](/sdks/server-sdks/go/assignments)

--- a/docs/sdks/server-sdks/go/quickstart.mdx
+++ b/docs/sdks/server-sdks/go/quickstart.mdx
@@ -29,7 +29,7 @@ First, initialize the SDK using your SDK key:
 
 ```go
 import (
-    "github.com/eppo-exp/golang-sdk/v6/eppoclient"
+    "github.com/Eppo-exp/golang-sdk/v6/eppoclient"
 )
 
 var eppoClient *eppoclient.EppoClient


### PR DESCRIPTION
As pointed out by a client:
https://eppo-group.slack.com/archives/C06GC8Z4EDS/p1742545731988389