### PR TITLE
Webhook signature verification instructions

### DIFF
--- a/docs/reference/webhook.mdx
+++ b/docs/reference/webhook.mdx
@@ -116,7 +116,7 @@ In short, any operation visible in the Flag History is sent to the webhook.
 
 ## Configuring the webhook
 
-To use the webhook, you first need to setup a URL on your side to receive the webhook payload.
+To use the webhook, you first need to setup a URL on your side to receive the webhook request.
 
 The configuration is done in the [Admin > Integrations](https://eppo.cloud/admin/integrations) page.
 
@@ -124,14 +124,14 @@ Once that is done, contact [Eppo support](emailto:support@geteppo.com) to custom
 
 ## Webhook Signature
 
-The webhook payload is signed with a signature. The signature is a hash of the payload and the webhook secret.
+The webhook request is signed with a signature. The signature is a hash of the `"data"` object in the webhook request body and the webhook secret.
 
 ### Integrating and Verifying the Signature
 
 To verify the webhook signature, you'll need to:
 
-1. Get the signature from the webhook payload
-2. Generate a HMAC SHA-256 hash of the raw request body using your webhook secret
+1. Get the signature from the webhook request body
+2. Generate a HMAC SHA-256 hash with your webhook secret and a string representation of the `"data"` object in the webhook request body
 3. Compare the generated hash with the received signature
 
 Here's an example in TypeScript/Node.js:
@@ -139,18 +139,18 @@ Here's an example in TypeScript/Node.js:
 ```typescript
 import crypto from 'crypto';
 
-function generateHMACSignature(secret: string, payload: string): string {
+function generateHMACSignature(secret: string, data: string): string {
   return crypto.createHmac('sha256', secret)
-    .update(payload)
+    .update(data)
     .digest('hex');
 }
 
 function isValidWebhookSignature(
-  payload: string,
+  data: string,
   signature: string,
   webhookSecret: string
 ): boolean {
-  const expectedSignature = generateHMACSignature(webhookSecret, payload);
+  const expectedSignature = generateHMACSignature(webhookSecret, data);
   return crypto.timingSafeEqual(
     Buffer.from(signature),
     Buffer.from(expectedSignature)
@@ -160,10 +160,10 @@ function isValidWebhookSignature(
 // Example usage in an Express route handler
 app.post('/webhook', (req, res) => {
   const signature = req.body.signature;
-  const payload = JSON.stringify(req.body);
+  const data = JSON.stringify(req.body.data);
   const webhookSecret = process.env.WEBHOOK_SECRET;
 
-  if (!isValidWebhookSignature(payload, signature, webhookSecret)) {
+  if (!isValidWebhookSignature(data, signature, webhookSecret)) {
     return res.status(401).send('Invalid signature');
   }
 

--- a/docs/reference/webhook.mdx
+++ b/docs/reference/webhook.mdx
@@ -20,7 +20,7 @@ you can filter to just the events you are interested in subscribing to based on 
 {
   "event": "experiment.metric.updated",
   "data": {
-    "experiment_id": "<experiment_id>",
+    "experiment_id": <experiment_id>,
     "experiment_key": "<experiment_key>"
   },
   "signature": "<signature>"
@@ -37,7 +37,7 @@ you can filter to just the events you are interested in subscribing to based on 
 {
   "event": "experiment.configuration.updated",
   "data": {
-    "experiment_id": "<experiment_id>",
+    "experiment_id": <experiment_id>,
     "experiment_key": "<experiment_key>"
   },
   "signature": "<signature>"
@@ -54,7 +54,7 @@ you can filter to just the events you are interested in subscribing to based on 
 {
   "event": "experiment.status.updated",
   "data": {
-    "experiment_id": "<experiment_id>",
+    "experiment_id": <experiment_id>,
     "experiment_key": "<experiment_key>"
   },
   "signature": "<signature>"
@@ -72,14 +72,14 @@ you can filter to just the events you are interested in subscribing to based on 
 {
   "event": "experiment.calculated_metrics.updated",
   "data": {
-    "experiment_id": "<experiment_id>",
+    "experiment_id": <experiment_id>,
     "experiment_key": "<experiment_key>",
     "meta_data": {
       "status": "<success | failure>",
-      "is_manual_refresh": "<boolean>",
-      "is_data_updated": "<boolean>",
-      "time_taken_seconds": "<number>",
-      "is_traffic_imbalance": "<boolean>",
+      "is_manual_refresh": <boolean>,
+      "is_data_updated": <boolean>,
+      "time_taken_seconds": <number>,
+      "is_traffic_imbalance": <boolean>,
       "assignments_scan_start_date": "<date>",
       "assignments_scan_end_date": "<date>"
 }
@@ -106,7 +106,7 @@ In short, any operation visible in the Flag History is sent to the webhook.
   "event": "flag.configuration.updated",
   "data": {
     "flag": {
-      "id": "<flag_id>",
+      "id": <flag_id>,
       "key": "<flag_key>"
     }
   },
@@ -131,7 +131,7 @@ The webhook request is signed with a signature. The signature is a hash of the `
 To verify the webhook signature, you'll need to:
 
 1. Get the signature from the webhook request body
-2. Generate a HMAC SHA-256 hash with your webhook secret and a string representation of the `"data"` object in the webhook request body
+2. Generate a HMAC SHA-256 hash with your webhook secret and the `"data"` in the webhook request body
 3. Compare the generated hash with the received signature
 
 Here's an example in TypeScript/Node.js:
@@ -173,5 +173,6 @@ app.post('/webhook', (req, res) => {
 ```
 
 :::note
-Always use a constant-time comparison function (like `crypto.timingSafeEqual`) when comparing signatures to prevent timing attacks.
+* Always use a constant-time comparison function (like `crypto.timingSafeEqual`) when comparing signatures to prevent timing attacks.
+* Ensure JSON data types are preserved before stringifying to generate the signature. For example, a numeric ID should remain a number (e.g., id: 123) and not be coerced into a string (e.g., id: "123"), as this will result in an incorrect signature.
 :::


### PR DESCRIPTION
[Link to linear](https://linear.app/eppo/issue/FF-4298/webhook-signature-verification-instructions)

Clarifications/corrections:

* Unclear what "payload" means: the entire event-data-signature object? But how could we possibly generate a signature if the payload already has a signature in it? It would be less confusing if we specify to use the "data" object in the request body.
* JSON data types must not be pre-coerced into strings before running through the signature matching algorithm. This was a subtle gotcha that it would be preferable to avoid in the future.