### PR TITLE
Sameeran/ff 4301 missing initialization parameters in js docs

### DIFF
--- a/docs/sdks/client-sdks/javascript/Initialization.mdx
+++ b/docs/sdks/client-sdks/javascript/Initialization.mdx
@@ -67,7 +67,7 @@ A small wait will be done between requests.
   defaultValue="false"
 >
 
-Poll for new **configurations** (every 30 seconds) after successfully requesting the initial configurations.
+Poll for a new configuration (every 30 seconds or as set in `pollingIntervalMs`) after successfully requesting the initial configurations.
 </ApiOptionRef>
 
 <ApiOptionRef 
@@ -76,7 +76,7 @@ Poll for new **configurations** (every 30 seconds) after successfully requesting
   defaultValue="false"
 >
 
-Poll for new configurations even if the initial configurations request failed.
+Poll for a new configuration even if the initial configurations request failed.
 </ApiOptionRef>
 
 <ApiOptionRef
@@ -85,7 +85,7 @@ Poll for new configurations even if the initial configurations request failed.
   defaultValue="30000"
 >
 
-Maximum amount of time to wait between calls to the API for the latest configuration.
+Maximum amount of time to wait between calls to the API for the latest configuration if polling is enabled.
 </ApiOptionRef>
 
 <ApiOptionRef 

--- a/docs/sdks/client-sdks/javascript/Initialization.mdx
+++ b/docs/sdks/client-sdks/javascript/Initialization.mdx
@@ -79,6 +79,15 @@ Poll for new **configurations** (every 30 seconds) after successfully requesting
 Poll for new configurations even if the initial configurations request failed.
 </ApiOptionRef>
 
+<ApiOptionRef
+  name="pollingIntervalMs"
+  type="number"
+  defaultValue="30000"
+>
+
+Maximum amount of time to wait between calls to the API for the latest configuration.
+</ApiOptionRef>
+
 <ApiOptionRef 
   name="throwOnFailedInitialization"
   type="boolean"

--- a/docs/sdks/client-sdks/react-native/initialization.mdx
+++ b/docs/sdks/client-sdks/react-native/initialization.mdx
@@ -68,12 +68,30 @@ The base URL for for the API. Can be overriden to proxy configuration requests.
 
 
 <ApiOptionRef 
+  name="pollAfterSuccessfulInitialization"
+  type="boolean"
+  defaultValue="false"
+>
+
+Poll for new **configurations** (every 30 seconds) after successfully requesting the initial configurations.
+</ApiOptionRef>
+
+<ApiOptionRef 
   name="pollAfterFailedInitialization"
   type="boolean"
   defaultValue="false"
 >
 
 Poll for new configurations even if the initial configurations request failed.
+</ApiOptionRef>
+
+<ApiOptionRef
+  name="pollingIntervalMs"
+  type="number"
+  defaultValue="30000"
+>
+
+Maximum amount of time to wait between calls to the API for the latest configuration.
 </ApiOptionRef>
 
 <ApiOptionRef 

--- a/docs/sdks/client-sdks/react-native/initialization.mdx
+++ b/docs/sdks/client-sdks/react-native/initialization.mdx
@@ -73,7 +73,7 @@ The base URL for for the API. Can be overriden to proxy configuration requests.
   defaultValue="false"
 >
 
-Poll for new **configurations** (every 30 seconds) after successfully requesting the initial configurations.
+Poll for a new configuration (every 30 seconds or as set in `pollingIntervalMs`) after successfully requesting the initial configurations.
 </ApiOptionRef>
 
 <ApiOptionRef 
@@ -91,7 +91,7 @@ Poll for new configurations even if the initial configurations request failed.
   defaultValue="30000"
 >
 
-Maximum amount of time to wait between calls to the API for the latest configuration.
+Maximum amount of time to wait between calls to the API for the latest configuration if polling is enabled.
 </ApiOptionRef>
 
 <ApiOptionRef 


### PR DESCRIPTION
I noticed some missing init config parameters in the docs for the JS client SDK and the react native SDK. While the additions here may do not address all the missing parameters, it's a step in the right direction.

