### PR TITLE
Add instructions on delaying sending assignments until a later time

### DIFF
--- a/docs/sdks/client-sdks/javascript/gdpr-compliance.mdx
+++ b/docs/sdks/client-sdks/javascript/gdpr-compliance.mdx
@@ -1,0 +1,40 @@
+---
+title: GDPR Compliance
+sidebar_position: 110
+---
+
+## Overview
+
+In certain situations, you may wish to hold off on logging assignments until a later time, such as the user granting
+the relevant permission.
+
+To handle this, you can initialize the SDK without an assignment logger and let it buffer events to be flushed later
+when permission has been granted.
+
+With no initial assignment logger, the SDK will buffer 10,000 events in memory, and will flush them when an assignment
+logger is later defined.
+
+## Code Example
+
+First, you want to initialize the SDK _without_ an assignment logger. We leverage TypeScript's typing to remind people to
+specify an assignment logger, so you will need to explicitly cast `null` in order to pass in while satisfying type
+checks.
+
+```ts
+await init({
+  apiKey: 'YOUR_SDK_KEY',
+  assignmentLogger: null as unknown as IAssignmentLogger,
+});
+```
+
+Once you are ready to send the buffered events, set the assignment logger.
+
+```ts
+getInstance().setAssignmentLogger({
+  logAssignment(assignment: IAssignmentEvent) {
+    console.log('Send to warehouse: ', assignmentEvent);
+  }
+});
+```
+
+Note that since assignments are buffered in memory, if the SDK is reinitialized any buffered assignments will be reset.

--- a/docs/sdks/client-sdks/javascript/troubleshooting.mdx
+++ b/docs/sdks/client-sdks/javascript/troubleshooting.mdx
@@ -1,11 +1,11 @@
 ---
 title: Troubleshooting
-sidebar_position: 100
+sidebar_position: 120
 ---
 
 ## Debugging
 
-You may encounter a situation where a flag assignment produces a value that you did not expect. There are functions [detailed here](/sdks/sdk-features/debugging-flag-assignment) to help you understand how flags are assigned, which will allow you to take corrective action on potential configuration issues. 
+You may encounter a situation where a flag assignment produces a value that you did not expect. There are functions [detailed here](/sdks/sdk-features/debugging-flag-assignment) to help you understand how flags are assigned, which will allow you to take corrective action on potential configuration issues.
 
 ## Supporting old browsers
 


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-4336 - Update JS Client SDK Docs for GDPR Compliance Approach](https://linear.app/eppo/issue/FF-4336/update-js-client-sdk-docs-for-gdpr-compliance-approach)

In certain situations, such as GDPR Compliance, one may want to buffer assignment events and send them at a later time.

Eppo's JavaScript Client SDK can handle this, and this documentation update includes instructions on how.

👀  [Direct link in deploy preview](https://deploy-preview-666--eppo-data-docs.netlify.app/sdks/client-sdks/javascript/gdpr-compliance/)