### PR TITLE
fix docs to enable overrides

### DIFF
--- a/docs/sdks/developer-tools-extension.md
+++ b/docs/sdks/developer-tools-extension.md
@@ -33,6 +33,7 @@ init({
     },
   },
   overridesStorageKey: 'eppo-overrides', // your overrides key goes here
+  enableOverrides: true,
 });
 ```
 


### PR DESCRIPTION
Add missing `enableOverrides` parameter to Eppo Developer Tools documentation