### PR TITLE
docs: add note about nested extraLogging field in holdout assignment logging

### DIFF
--- a/docs/feature-flagging/concepts/holdout-config.md
+++ b/docs/feature-flagging/concepts/holdout-config.md
@@ -100,3 +100,5 @@ class MyAssignmentLogger(AssignmentLogger):
         })
 ```
 
+> **Note:** Some SDK implementations may nest the holdout information within an `extraLogging` field. If you don't see `holdoutKey` and `holdoutVariation` at the top level of the event, check for them in `event.extraLogging.holdoutKey` and `event.extraLogging.holdoutVariation`.
+


### PR DESCRIPTION
Add a note to the holdout configuration documentation to help users locate holdout information when their SDK implementation nests it within the extraLogging field rather than flattening it to the top level.