### PR TITLE
docs: add RequestTimeoutMillis option to .NET SDK initialization docs

### DIFF
--- a/docs/sdks/server-sdks/dotnet/initialization.mdx
+++ b/docs/sdks/server-sdks/dotnet/initialization.mdx
@@ -58,6 +58,15 @@ The maximum amount of time in milliseconds to add to the polling interval.
 </ApiOptionRef>
 
 <ApiOptionRef 
+  name="RequestTimeoutMillis"
+  type="number"
+  defaultValue="1000"
+>
+
+**Timeout** in milliseconds for HTTPS requests for the experiment configurations.
+</ApiOptionRef>
+
+<ApiOptionRef 
   name="AssignmentLogger"
   type="IAssignmentLogger"
   defaultValue="null"


### PR DESCRIPTION
See https://github.com/Eppo-exp/dot-net-server-sdk/pull/63