### PR TITLE
Documentation for setLogLevel()

### DIFF
--- a/docs/sdks/client-sdks/javascript/troubleshooting.mdx
+++ b/docs/sdks/client-sdks/javascript/troubleshooting.mdx
@@ -5,6 +5,12 @@ sidebar_position: 120
 
 ## Debugging
 
+By default the log level for the SDK is set to `warn`.
+You can change this by calling the `setLogLevel` option on the SDK.
+```ts
+eppoClient.setLogLevel('debug');
+```
+
 You may encounter a situation where a flag assignment produces a value that you did not expect. There are functions [detailed here](/sdks/sdk-features/debugging-flag-assignment) to help you understand how flags are assigned, which will allow you to take corrective action on potential configuration issues.
 
 ## Supporting old browsers


### PR DESCRIPTION
🎟️ **Ticket:** [FFESUPPORT-100 - Legacy Eppo Browser SDK has browser logging hard-coded off](https://datadoghq.atlassian.net/browse/FFESUPPORT-100)
👯 **Related PRs:**
* [`js-sdk-common #296` - Fix browser logging fixes](https://github.com/Eppo-exp/js-sdk-common/pull/296)
* [`js-client-sdk #257` - Fix browser logging fixes](https://github.com/Eppo-exp/js-client-sdk/pull/257)

We're adding a new `setLogLevel()` method on the Eppo JavaScript SDK.