### PR TITLE
Clarify Switchback subentity setup is on Assignment SQL, not FactSQL

### DIFF
--- a/docs/experiment-analysis/switchbacks.md
+++ b/docs/experiment-analysis/switchbacks.md
@@ -36,10 +36,24 @@ We'll now provide a step-by-step walkthrough for creating Switchback Assignment 
 
 ![Configuring the Switchback assignment SQL](/img/experiments/switchbacks/switchback-assignments.png)
    
-### Updates to FactSQL
-FactSQL that corresponds to metrics you want to monitor also need to be updated with the Switchback entity. On the FactSQL page, click edit and add a new subentity that corresponds to the Switchback entity. 
+### Configure the analysis entity (subentity)
 
-You do not need to make any changes to metrics.
+A Switchback randomizes over the environment (e.g. market or region), but metrics are measured on a per-subject **analysis entity** (e.g. users). Eppo joins each subject's events to the switchback variation they were exposed to, so it needs to know which entity the analysis is run on. This entity is referred to as the **subentity**.
+
+The subentity is configured on the **Assignment SQL**, not on FactSQL:
+
+1. Navigate to Definitions and edit the Assignment SQL for the analysis entity (e.g. the user-level assignment source).
+2. Click **Add Subentities** and select the analysis entity along with the column in the SQL that holds its ID.
+
+:::note
+The **Add Subentities** option is part of Eppo's clustered analysis support and may be gated behind a feature flag for your workspace. If you don't see it, reach out to your Eppo contact to have it enabled.
+:::
+
+### Updates to FactSQL
+
+FactSQL that corresponds to metrics you want to monitor must expose a column for the analysis entity (the subentity), so that fact events can be joined to the switchback assignments. If a Fact SQL definition does not already map that entity, open it, click **Edit**, and add the analysis entity as one of its entities (the same way you would add any other entity to a Fact SQL).
+
+You do not need to make any changes to the metrics themselves — only ensure the underlying Fact SQL surfaces the analysis entity.
 
 ## Create switchback analysis
 


### PR DESCRIPTION
## Summary

The Switchback docs' **Updates to FactSQL** section told users to "click edit and add a new subentity that corresponds to the Switchback entity" on the **FactSQL** page. That control does not exist on Fact SQL — it caused confusion for a customer setting up a switchback who could not find any way to "add a subentity to the fact."

Validated against the backend code (`eppo` repo):
- Subentities are a property of the **Assignment SQL** (`assignment_source_subentities`, surfaced in the UI via **Add Subentities**, gated behind the `clustered-analysis` flag). There is no subentity control on Fact SQL.
- For switchback/clustered analysis, facts join to assignments on `fact.subject = assignment.subentity` (`getSubjectSelectTerms` → `assignmentJoinColumn = 'subentity'` in `unified-blocks.ts`). The fact's `subject` is just a normal entity column (`metricEventEntity.entityColumnName`).
- So the real requirement is: the Fact SQL must expose an entity column for the **analysis entity** (the subentity, e.g. users), and metrics are defined on that subentity — not on the cluster/switchback entity. This matches the existing "you do not need to make changes to metrics" note.

## Changes

- Add a **Configure the analysis entity (subentity)** subsection explaining that the subentity is configured on the **Assignment SQL** via **Add Subentities** (with a note that it's part of clustered analysis and may be flag-gated).
- Rewrite **Updates to FactSQL** to state the actual requirement: the Fact SQL must surface the analysis entity column (added like any other entity), with no per-fact "subentity" step.

## Test plan

- [x] Docs preview renders the two subsections correctly under "Configure Switchback assignments".